### PR TITLE
Refactor RegisterForDeviceAccessStatusChange

### DIFF
--- a/source/USB Test App WPF/App.xaml.cs
+++ b/source/USB Test App WPF/App.xaml.cs
@@ -19,6 +19,8 @@ namespace USB_Test_App_WPF
     {
         ViewModelLocator vml;
 
+        internal static PortBase NanoFrameworkSerialDebugClient;
+
         public App()
         {
             this.Activated += App_Activated;

--- a/source/USB Test App WPF/MainWindow.xaml
+++ b/source/USB Test App WPF/MainWindow.xaml
@@ -23,6 +23,7 @@
                 <DataGridTextColumn Binding="{Binding Description}"/>
             </DataGrid.Columns>
         </DataGrid>
+        <Button Content="Connect" HorizontalAlignment="Left" Margin="59,219,0,0" VerticalAlignment="Top" Width="75" Click="ConnectDeviceButton_ClickAsync"/>
 
     </Grid>
 </Window>

--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -24,6 +25,28 @@ namespace USB_Test_App_WPF
         public MainWindow()
         {
             InitializeComponent();
+        }
+
+        private async void ConnectDeviceButton_ClickAsync(object sender, RoutedEventArgs e)
+        {
+            // disable button
+            (sender as Button).IsEnabled = false;
+
+
+            
+            bool connectResult = await (DataContext as MainViewModel).AvailableDevices[0].DebugEngine.ConnectAsync(3, 1000);
+
+            //var di = await App.NETMFUsbDebugClient.MFDevices[0].GetDeviceInfoAsync();
+
+            Debug.WriteLine("");
+            Debug.WriteLine("");
+            //Debug.WriteLine(di.ToString());
+            Debug.WriteLine("");
+            Debug.WriteLine("");
+
+            // enable button
+            (sender as Button).IsEnabled = true;
+
         }
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Net/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/PortSerial/EventHandlerForSerialDevice.cs
@@ -61,6 +61,15 @@ namespace nanoFramework.Tools.Debugger.Serial
         }
 
         /// <summary>
+        /// This is an empty method just to keep the workflow unchanged between UWP and Desktop version.
+        /// The DeviceAccessStatusChange is only available in UWP.
+        /// </summary>
+        private void RegisterForDeviceAccessStatusChange()
+        {
+
+        }
+
+        /// <summary>
         /// If a SerialDevice object has been instantiated (a handle to the device is opened), we must close it before the app 
         /// goes into suspension because the API automatically closes it for us if we don't. When resuming, the API will
         /// not reopen the device automatically, so we need to explicitly open the device in that situation.

--- a/source/nanoFramework.Tools.DebugLibrary.Net/Properties/AssemblyInfo.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/Properties/AssemblyInfo.cs
@@ -5,12 +5,12 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("nanoFramework.Tools.DebugLibrary.Net")]
+[assembly: AssemblyTitle("nanoFramework Debug Library")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("nanoFramework.Tools.DebugLibrary.Net")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyCompany("The nanoFramework project contributors")]
+[assembly: AssemblyProduct("nanoFramework Debug Library")]
+[assembly: AssemblyCopyright("Copyright © 2017 nanoFramework project contributors")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("0.3.*")]
+[assembly: AssemblyFileVersion("0.3.5.0")]

--- a/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
@@ -16,7 +16,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <PackageId>nanoFramework.Tools.Debugger.Net</PackageId>
-    <PackageVersion>0.3.0-preview004</PackageVersion>
+    <PackageVersion>0.3.0-preview005</PackageVersion>
     <Description>This .NET library provides a debug client for nanoFramework devices using USB or Serial connection to a board.</Description>
     <Authors>nanoFramework project contributors</Authors>
     <Title>nanoFramework debug library for .NET</Title>

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/EventHandlerForSerialDevice.cs
@@ -399,21 +399,6 @@ namespace nanoFramework.Tools.Debugger.Serial
             deviceRemovedEventHandler = null;
         }
 
-        /// <summary>
-        /// Listen for any changed in device access permission. The user can block access to the device while the device is in use.
-        /// If the user blocks access to the device while the device is opened, the device's handle will be closed automatically by
-        /// the system; it is still a good idea to close the device explicitly so that resources are cleaned up.
-        /// 
-        /// Note that by the time the AccessChanged event is raised, the device handle may already be closed by the system.
-        /// </summary>
-        private void RegisterForDeviceAccessStatusChange()
-        {
-            deviceAccessInformation = DeviceAccessInformation.CreateFromId(deviceInformation.Id);
-
-            deviceAccessEventHandler = new TypedEventHandler<DeviceAccessInformation, DeviceAccessChangedEventArgs>(OnDeviceAccessChanged);
-            deviceAccessInformation.AccessChanged += deviceAccessEventHandler;
-        }
-
         private void UnregisterFromDeviceAccessStatusChange()
         {
             deviceAccessInformation.AccessChanged -= deviceAccessEventHandler;

--- a/source/nanoFramework.Tools.DebugLibrary.UWP/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.UWP/PortSerial/EventHandlerForSerialDevice.cs
@@ -73,6 +73,21 @@ namespace nanoFramework.Tools.Debugger.Serial
         }
 
         /// <summary>
+        /// Listen for any changed in device access permission. The user can block access to the device while the device is in use.
+        /// If the user blocks access to the device while the device is opened, the device's handle will be closed automatically by
+        /// the system; it is still a good idea to close the device explicitly so that resources are cleaned up.
+        /// 
+        /// Note that by the time the AccessChanged event is raised, the device handle may already be closed by the system.
+        /// </summary>
+        private void RegisterForDeviceAccessStatusChange()
+        {
+            deviceAccessInformation = DeviceAccessInformation.CreateFromId(deviceInformation.Id);
+
+            deviceAccessEventHandler = new TypedEventHandler<DeviceAccessInformation, DeviceAccessChangedEventArgs>(OnDeviceAccessChanged);
+            deviceAccessInformation.AccessChanged += deviceAccessEventHandler;
+        }
+
+        /// <summary>
         /// If a SerialDevice object has been instantiated (a handle to the device is opened), we must close it before the app 
         /// goes into suspension because the API automatically closes it for us if we don't. When resuming, the API will
         /// not reopen the device automatically, so we need to explicitly open the device in that situation.

--- a/source/nanoFramework.Tools.DebugLibrary.UWP/Properties/AssemblyInfo.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.UWP/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("nanoFramework Debug Library")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("nanoFramework")]
-[assembly: AssemblyProduct("Debug Library")]
-[assembly: AssemblyCopyright("Copyright (c) 2017 The nanoFramework project contributors")]
+[assembly: AssemblyCompany("The nanoFramework project contributors")]
+[assembly: AssemblyProduct("nanoFramework Debug Library")]
+[assembly: AssemblyCopyright("Copyright © 2017 nanoFramework project contributors")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.*")]
-[assembly: AssemblyFileVersion("0.2.20.0")]
+[assembly: AssemblyVersion("0.3.*")]
+[assembly: AssemblyFileVersion("0.3.5.0")]
 [assembly: ComVisible(false)]

--- a/source/nanoFramework.Tools.DebugLibrary.UWP/nanoFramework.Tools.DebugLibrary.UWP.csproj
+++ b/source/nanoFramework.Tools.DebugLibrary.UWP/nanoFramework.Tools.DebugLibrary.UWP.csproj
@@ -17,7 +17,7 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <PackageId>nanoFramework.Tools.Debugger.UWP</PackageId>
-    <PackageVersion>0.3.0-preview004</PackageVersion>
+    <PackageVersion>0.3.0-preview005</PackageVersion>
     <Description>This UWP library provides a debug client for nanoFramework devices using USB or Serial connection to a board.</Description>
     <Authors>nanoFramework project contributors</Authors>
     <Title>nanoFramework debug library for UWP</Title>
@@ -129,6 +129,7 @@ For .NET look for the respective Nuget package.</PackageReleaseNotes>
     <Compile Include="PortDefinitions\PortBase.cs" />
     <Compile Include="PortSerial\EventHandlerForSerialDevice.cs" />
     <Compile Include="PortSerial\SerialPort.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="..\nanoFramework.Tools.DebugLibrary.Shared\nanoFramework.Tools.DebugLibrary.Net.projitems" Label="Shared" />


### PR DESCRIPTION
- DeviceAccessInformation is only available in UWP, therefore calling it was crashing the component, refactor by provinding different implementation for each variant
- fix #14 (only for Serial, still occurs in USB)
- add version and properties to debugger library projects

Signed-off-by: José Simões <jose.simoes@eclo.solutions>