### PR TITLE
Work on DebuggingResolveAssembly

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml
+++ b/source/USB Test App WPF/MainWindow.xaml
@@ -23,9 +23,13 @@
                 <DataGridTextColumn Binding="{Binding Description}"/>
             </DataGrid.Columns>
         </DataGrid>
-        <Button Content="Connect" HorizontalAlignment="Left" Margin="59,219,0,0" VerticalAlignment="Top" Width="75" Click="ConnectDeviceButton_ClickAsync"/>
-        <Button Content="Ping" HorizontalAlignment="Left" Margin="59,259,0,0" VerticalAlignment="Top" Width="75" Click="PingButton_Click" />
-        <Button Content="Disconnect" HorizontalAlignment="Left" Margin="196,219,0,0" VerticalAlignment="Top" Width="75" Click="DisconnectDeviceButton_Click"/>
+        <Button Content="Connect" HorizontalAlignment="Left" Margin="250,77,0,0" VerticalAlignment="Top" Width="75" Click="ConnectDeviceButton_ClickAsync"/>
+        <Button Content="Disconnect" HorizontalAlignment="Left" Margin="250,102,0,0" VerticalAlignment="Top" Width="75" Click="DisconnectDeviceButton_Click"/>
+
+        <Button Content="Ping" HorizontalAlignment="Left" Margin="39,195,0,0" VerticalAlignment="Top" Width="75" Click="PingButton_Click" />
+        <Button Content="Is Initialized" HorizontalAlignment="Left" Margin="154,195,0,0" VerticalAlignment="Top" Width="75" Click="IsInitializedButton_Click" />
+        <Button Content="Resolve Assemblies" HorizontalAlignment="Left" Margin="39,235,0,0" VerticalAlignment="Top" Width="75" Click="ResolveAssembliesButton_Click" />
+
 
     </Grid>
 </Window>

--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -1,8 +1,10 @@
-﻿using System;
+﻿using nanoFramework.Tools.Debugger.Extensions;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -101,6 +103,71 @@ namespace USB_Test_App_WPF
                 }
 
             }));
+
+            // enable button
+            (sender as Button).IsEnabled = true;
+        }
+
+        private async void IsInitializedButton_Click(object sender, RoutedEventArgs e)
+        {
+            // disable button
+            (sender as Button).IsEnabled = false;
+
+            await Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(async () =>
+             {
+
+                 try
+                 {
+                     var result = await (DataContext as MainViewModel).AvailableDevices[0].DebugEngine.IsDeviceInInitializeStateAsync();
+
+                     Debug.WriteLine($">>> Device is in initialized state: {result} <<<<");
+
+                    //Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() => {
+                    //    ConnectionStateResult = ConnectionState.Disconnected;
+                    //}));
+                }
+                 catch (Exception ex)
+                 {
+
+                 }
+
+             }));
+
+            // enable button
+            (sender as Button).IsEnabled = true;
+        }
+        private async void ResolveAssembliesButton_Click(object sender, RoutedEventArgs e)
+        {
+            // disable button
+            (sender as Button).IsEnabled = false;
+
+            await Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(async () =>
+             {
+
+                 try
+                 {
+                     // Create cancelation token source
+                     CancellationTokenSource cts = new CancellationTokenSource();
+
+                     var result = await (DataContext as MainViewModel).AvailableDevices[0].DebugEngine.ResolveAllAssembliesAsync(cts.Token);
+
+                     Debug.WriteLine("Assembly list:");
+                     
+                     foreach (nanoFramework.Tools.Debugger.WireProtocol.Commands.DebuggingResolveAssembly assembly in result)
+                     {
+                         Debug.WriteLine($" {assembly.Idx} :: {assembly.Result.Name} [{assembly.Result.Path}]");
+                     }
+
+                    //Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() => {
+                    //    ConnectionStateResult = ConnectionState.Disconnected;
+                    //}));
+                }
+                 catch (Exception ex)
+                 {
+
+                 }
+
+             }));
 
             // enable button
             (sender as Button).IsEnabled = true;

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/Extensions/DebuggerExtensions.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/Extensions/DebuggerExtensions.cs
@@ -1,0 +1,32 @@
+﻿//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Tools.Debugger.Extensions
+{
+    public static class DebuggerExtensions
+    {
+        /// <summary>
+        /// Check if device is in initialized state.
+        /// </summary>
+        /// <param name="debugEngine"></param>
+        /// <returns></returns>
+        public static async System.Threading.Tasks.Task<bool> IsDeviceInInitializeStateAsync(this Engine debugEngine)
+        {
+            try
+            {
+                var result = await debugEngine.SetExecutionModeAsync(0, 0);
+                if (result.Item2)
+                {
+                    return ((result.Item1 & WireProtocol.Commands.Debugging_Execution_ChangeConditions.c_State_Mask) == WireProtocol.Commands.Debugging_Execution_ChangeConditions.c_State_Initialize);
+                }
+            }
+            catch
+            {
+            }
+
+            return false;
+        }
+    }
+}

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/AssemblyInfoFromResolveAssembly.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/AssemblyInfoFromResolveAssembly.cs
@@ -11,43 +11,43 @@ namespace nanoFramework.Tools.Debugger
 {
     class AssemblyInfoFromResolveAssembly : IAssemblyInfo
     {
-        private Commands.Debugging_Resolve_Assembly m_dra;
-        private List<IAppDomainInfo> m_AppDomains = new List<IAppDomainInfo>();
+        private Commands.DebuggingResolveAssembly _dra;
+        private List<IAppDomainInfo> _appDomains = new List<IAppDomainInfo>();
 
-        public AssemblyInfoFromResolveAssembly(Commands.Debugging_Resolve_Assembly dra)
+        public AssemblyInfoFromResolveAssembly(Commands.DebuggingResolveAssembly dra)
         {
-            m_dra = dra;
+            _dra = dra;
         }
 
         public string Name
         {
-            get { return m_dra.m_reply.Name; }
+            get { return _dra.Result.Name; }
         }
 
         public System.Version Version
         {
             get
             {
-                Commands.Debugging_Resolve_Assembly.Version draver = m_dra.m_reply.m_version;
-                return new System.Version(draver.iMajorVersion, draver.iMinorVersion, draver.iBuildNumber, draver.iRevisionNumber);
+                Commands.DebuggingResolveAssembly.Version version = _dra.Result.Version;
+                return new System.Version(version.MajorVersion, version.MinorVersion, version.BuildNumber, version.RevisionNumber);
             }
         }
 
         public uint Index
         {
-            get { return m_dra.m_idx; }
+            get { return _dra.Idx; }
         }
 
         public List<IAppDomainInfo> InAppDomains
         {
-            get { return m_AppDomains; }
+            get { return _appDomains; }
         }
 
         public void AddDomain(IAppDomainInfo adi)
         {
             if (adi != null)
             {
-                m_AppDomains.Add(adi);
+                _appDomains.Add(adi);
             }
         }
     }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/NanoFrameworkDeviceInfo.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/NanoFrameworkDeviceInfo.cs
@@ -56,7 +56,7 @@ namespace nanoFramework.Tools.Debugger
 
                 if (domainsReply != null)
                 {
-                    foreach (uint id in domainsReply.m_data)
+                    foreach (uint id in domainsReply.Data)
                     {
                         Commands.Debugging_Resolve_AppDomain.Reply reply = await Dbg.ResolveAppDomainAsync(id);
                         // TODO add cancelation token code
@@ -71,10 +71,10 @@ namespace nanoFramework.Tools.Debugger
 
         private async Task GetAssembliesAsync(CancellationToken cancellationToken)
         {
-            List<Commands.Debugging_Resolve_Assembly> reply = await Dbg.ResolveAllAssembliesAsync(cancellationToken);
+            List<Commands.DebuggingResolveAssembly> reply = await Dbg.ResolveAllAssembliesAsync(cancellationToken);
 
             if (reply != null)
-                foreach (Commands.Debugging_Resolve_Assembly resolvedAssm in reply)
+                foreach (Commands.DebuggingResolveAssembly resolvedAssm in reply)
                 {
                     AssemblyInfoFromResolveAssembly ai = new AssemblyInfoFromResolveAssembly(resolvedAssm);
 

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -1117,11 +1117,11 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
         public class Debugging_Reply_Uint_Array : IConverter
         {
-            public uint[] m_data = null;
+            public uint[] Data = null;
 
             public void PrepareForDeserialize(int size, byte[] data, Converter converter)
             {
-                m_data = new uint[(size) / 4];
+                Data = new uint[(size) / 4];
             }
         }
 
@@ -1190,48 +1190,45 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             }
         }
 
-        public class Debugging_Resolve_Assembly
+        public class DebuggingResolveAssembly
         {
-            public uint m_idx = 0;
+            public uint Idx = 0;
 
             [IgnoreDataMemberAttribute]
-            public Reply m_reply;
+            public Reply Result;
 
             public struct Version
             {
-                public ushort iMajorVersion;
-                public ushort iMinorVersion;
-                public ushort iBuildNumber;
-                public ushort iRevisionNumber;
+                public ushort MajorVersion;
+                public ushort MinorVersion;
+                public ushort BuildNumber;
+                public ushort RevisionNumber;
 
                 public override string ToString()
                 {
-                    return string.Format("{0}.{1}.{2}.{3}", iMajorVersion, iMinorVersion, iBuildNumber, iRevisionNumber);
+                    return string.Format("{0}.{1}.{2}.{3}", MajorVersion, MinorVersion, BuildNumber, RevisionNumber);
                 }
             }
 
             public class Reply
             {
-                public const uint c_Resolved = 0x00000001;
-                public const uint c_Patched = 0x00000002;
-                public const uint c_PreparedForExecution = 0x00000004;
-                public const uint c_Deployed = 0x00000008;
-                public const uint c_PreparingForExecution = 0x00000010;
-
-                public uint m_flags;
-                public Version m_version;
-                public byte[] m_nameBuffer = new byte[512]; // char
+                ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                // the fields bellow have to be here AND follow the exact type and order so that the reply of the device can be properly parsed
+                public uint Flags;
+                public Version Version;
+                public byte[] NameBuffer = new byte[512]; // char
+                ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
                 [IgnoreDataMemberAttribute]
-                private string m_name;
+                private string _name;
                 [IgnoreDataMemberAttribute]
-                private string m_path;
+                private string _path;
 
                 private void EnsureName()
                 {
-                    if (m_name == null)
+                    if (_name == null)
                     {
-                        string name = Commands.GetZeroTerminatedString(m_nameBuffer, false);
+                        string name = Commands.GetZeroTerminatedString(NameBuffer, false);
                         string path = null;
 
                         int iComma = name.IndexOf(',');
@@ -1242,8 +1239,8 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                             name = name.Substring(0, iComma);
                         }
 
-                        m_name = name;
-                        m_path = path;
+                        _name = name;
+                        _path = path;
                     }
                 }
 
@@ -1253,7 +1250,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                     {
                         EnsureName();
 
-                        return m_name;
+                        return _name;
                     }
                 }
 
@@ -1263,7 +1260,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                     {
                         EnsureName();
 
-                        return m_path;
+                        return _path;
                     }
                 }
             }
@@ -1564,7 +1561,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                     case c_Debugging_Resolve_Type: return new Debugging_Resolve_Type.Reply();
                     case c_Debugging_Resolve_Field: return new Debugging_Resolve_Field.Reply();
                     case c_Debugging_Resolve_Method: return new Debugging_Resolve_Method.Reply();
-                    case c_Debugging_Resolve_Assembly: return new Debugging_Resolve_Assembly.Reply();
+                    case c_Debugging_Resolve_Assembly: return new DebuggingResolveAssembly.Reply();
                     case c_Debugging_Resolve_VirtualMethod: return new Debugging_Resolve_VirtualMethod.Reply();
                     case c_Debugging_Resolve_AppDomain: return new Debugging_Resolve_AppDomain.Reply();
 
@@ -1650,7 +1647,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                     case c_Debugging_Resolve_Type: return new Debugging_Resolve_Type();
                     case c_Debugging_Resolve_Field: return new Debugging_Resolve_Field();
                     case c_Debugging_Resolve_Method: return new Debugging_Resolve_Method();
-                    case c_Debugging_Resolve_Assembly: return new Debugging_Resolve_Assembly();
+                    case c_Debugging_Resolve_Assembly: return new DebuggingResolveAssembly();
                     case c_Debugging_Resolve_VirtualMethod: return new Debugging_Resolve_VirtualMethod();
                     case c_Debugging_Resolve_AppDomain: return new Debugging_Resolve_AppDomain();
 

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Controller.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Controller.cs
@@ -63,13 +63,13 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         {
             byte[] buf = Encoding.UTF8.GetBytes(sig);
 
-            Array.Copy(buf, 0, bp.m_signature, 0, buf.Length);
+            Array.Copy(buf, 0, bp.Signature, 0, buf.Length);
         }
 
         public async Task<bool> QueueOutputAsync(MessageRaw raw, CancellationToken cancellationToken)
         {
             Debug.WriteLine("QueueOutputAsync 1");
-            await SendRawBufferAsync(raw.m_header, TimeSpan.FromMilliseconds(1000), cancellationToken).ConfigureAwait(false);
+            await SendRawBufferAsync(raw.Header, TimeSpan.FromMilliseconds(1000), cancellationToken).ConfigureAwait(false);
 
             // check for cancelation request
             if (cancellationToken.IsCancellationRequested)
@@ -79,11 +79,11 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 return false;
             }
 
-            if (raw.m_payload != null)
+            if (raw.Payload != null)
             {
                 Debug.WriteLine("QueueOutputAsync 2");
 
-                await SendRawBufferAsync(raw.m_payload, TimeSpan.FromMilliseconds(1000), cancellationToken).ConfigureAwait(false);
+                await SendRawBufferAsync(raw.Payload, TimeSpan.FromMilliseconds(1000), cancellationToken).ConfigureAwait(false);
             }
 
             return true;
@@ -98,7 +98,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
             SetSignature(bp, marker);
 
-            bp.m_seq = (ushort)Interlocked.Increment(ref lastOutboundMessage);
+            bp.Seq = (ushort)Interlocked.Increment(ref lastOutboundMessage);
 
             return bp;
         }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -1309,23 +1309,25 @@ namespace nanoFramework.Tools.Debugger
             return null;
         }
 
-        public async Task<List<Commands.Debugging_Resolve_Assembly>> ResolveAllAssembliesAsync(CancellationToken cancellationToken)
+        public async Task<List<Commands.DebuggingResolveAssembly>> ResolveAllAssembliesAsync(CancellationToken cancellationToken)
         {
             Commands.Debugging_TypeSys_Assemblies.Reply assemblies = await GetAssembliesAsync(cancellationToken).ConfigureAwait(false);
-            List<Commands.Debugging_Resolve_Assembly> resolveAssemblies = new List<Commands.Debugging_Resolve_Assembly>();
+            List<Commands.DebuggingResolveAssembly> resolveAssemblies = new List<Commands.DebuggingResolveAssembly>();
 
-            if (assemblies == null || assemblies.m_data == null)
+            if (assemblies == null || assemblies.Data == null)
             {
-                resolveAssemblies = new List<Commands.Debugging_Resolve_Assembly>();
+                resolveAssemblies = new List<Commands.DebuggingResolveAssembly>();
             }
             else
             {
                 List<OutgoingMessage> requests = new List<OutgoingMessage>();
 
-                foreach(uint iAssembly in assemblies.m_data)
+                foreach(uint iAssembly in assemblies.Data)
                 {
-                    Commands.Debugging_Resolve_Assembly cmd = new Commands.Debugging_Resolve_Assembly();
-                    cmd.m_idx = iAssembly;
+                    Commands.DebuggingResolveAssembly cmd = new Commands.DebuggingResolveAssembly()
+                    {
+                        Idx = iAssembly
+                    };
 
                     requests.Add(CreateMessage(Commands.c_Debugging_Resolve_Assembly, 0, cmd));
                 }
@@ -1335,25 +1337,25 @@ namespace nanoFramework.Tools.Debugger
                 foreach(IncomingMessage message in replies)
                 {
                     // reply is a match for request which m_seq is same as reply m_seqReply
-                    resolveAssemblies.Add(requests.Find(req => req.Header.m_seq == message.Header.m_seqReply).Payload as Commands.Debugging_Resolve_Assembly);
-                    resolveAssemblies[resolveAssemblies.Count - 1].m_reply = message.Payload as Commands.Debugging_Resolve_Assembly.Reply;
+                    resolveAssemblies.Add(requests.Find(req => req.Header.Seq == message.Header.SeqReply).Payload as Commands.DebuggingResolveAssembly);
+                    resolveAssemblies[resolveAssemblies.Count - 1].Result = message.Payload as Commands.DebuggingResolveAssembly.Reply;
                 }
             }
 
             return resolveAssemblies;
         }
 
-        public async Task<Commands.Debugging_Resolve_Assembly.Reply> ResolveAssemblyAsync(uint idx)
+        public async Task<Commands.DebuggingResolveAssembly.Reply> ResolveAssemblyAsync(uint idx)
         {
-            Commands.Debugging_Resolve_Assembly cmd = new Commands.Debugging_Resolve_Assembly();
+            Commands.DebuggingResolveAssembly cmd = new Commands.DebuggingResolveAssembly();
 
-            cmd.m_idx = idx;
+            cmd.Idx = idx;
 
             IncomingMessage reply = await PerformRequestAsync(Commands.c_Debugging_Resolve_Assembly, 0, cmd).ConfigureAwait(false);
 
             if (reply != null)
             {
-                return reply.Payload as Commands.Debugging_Resolve_Assembly.Reply;
+                return reply.Payload as Commands.DebuggingResolveAssembly.Reply;
             }
 
             return null;

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/IncomingMessage.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/IncomingMessage.cs
@@ -52,7 +52,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         {
             get
             {
-                return m_base.m_header;
+                return m_base.Header;
             }
         }
 
@@ -60,32 +60,32 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         {
             get
             {
-                return m_base.m_payload;
+                return m_base.Payload;
             }
             set
             {
                 object payload = null;
 
-                if (m_raw.m_payload != null)
+                if (m_raw.Payload != null)
                 {
                     if (value != null)
                     {
-                        new Converter(m_parent.Capabilities).Deserialize(value, m_raw.m_payload);
+                        new Converter(m_parent.Capabilities).Deserialize(value, m_raw.Payload);
                         payload = value;
                     }
                     else
                     {
-                        payload = m_raw.m_payload.Clone();
+                        payload = m_raw.Payload.Clone();
                     }
                 }
 
-                m_base.m_payload = payload;
+                m_base.Payload = payload;
             }
         }
 
         static public bool IsPositiveAcknowledge(IncomingMessage reply)
         {
-            return reply != null && ((reply.Header.m_flags & WireProtocol.Flags.c_ACK) != 0);
+            return reply != null && ((reply.Header.Flags & WireProtocol.Flags.c_ACK) != 0);
         }
 
         static public async Task<bool> ReplyBadPacketAsync(IController ctrl, uint flags, CancellationToken cancellationToken)

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/MessageBase.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/MessageBase.cs
@@ -8,7 +8,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 {
     public class MessageBase
     {
-        public Packet m_header;
-        public object m_payload;
+        public Packet Header;
+        public object Payload;
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/MessageRaw.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/MessageRaw.cs
@@ -8,7 +8,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 {
     public class MessageRaw
     {
-        public byte[] m_header;
-        public byte[] m_payload;
+        public byte[] Header;
+        public byte[] Payload;
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/OutgoingMessage.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/OutgoingMessage.cs
@@ -12,10 +12,10 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 {
     public class OutgoingMessage
     {
-        internal IController m_parent;
+        internal IController _parent;
 
-        MessageRaw m_raw;
-        MessageBase m_base;
+        MessageRaw _raw;
+        MessageBase _base;
 
         public OutgoingMessage(IController parent, Converter converter, uint cmd, uint flags, object payload)
         {
@@ -26,10 +26,10 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
         internal OutgoingMessage(IncomingMessage req, Converter converter, uint flags, object payload)
         {
-            InitializeForSend(req.Parent, converter, req.Header.m_cmd, flags, payload);
+            InitializeForSend(req.Parent, converter, req.Header.Cmd, flags, payload);
 
-            m_base.m_header.m_seqReply = req.Header.m_seq;
-            m_base.m_header.m_flags |= Flags.c_Reply;
+            _base.Header.SeqReply = req.Header.Seq;
+            _base.Header.Flags |= Flags.c_Reply;
 
             UpdateCRC(converter);
         }
@@ -38,7 +38,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         {
             get
             {
-                return m_base.m_header;
+                return _base.Header;
             }
         }
 
@@ -46,7 +46,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         {
             get
             {
-                return m_base.m_payload;
+                return _base.Payload;
             }
         }
 
@@ -54,51 +54,51 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         {
             Packet header = parent.NewPacket();
 
-            header.m_cmd = cmd;
-            header.m_flags = flags;
+            header.Cmd = cmd;
+            header.Flags = flags;
 
-            m_parent = parent;
+            _parent = parent;
 
-            m_raw = new MessageRaw();
-            m_base = new MessageBase();
-            m_base.m_header = header;
-            m_base.m_payload = payload;
+            _raw = new MessageRaw();
+            _base = new MessageBase();
+            _base.Header = header;
+            _base.Payload = payload;
 
             if (payload != null)
             {
-                m_raw.m_payload = converter.Serialize(payload);
+                _raw.Payload = converter.Serialize(payload);
 
-                m_base.m_header.m_size = (uint)m_raw.m_payload.Length;
-                m_base.m_header.m_crcData = CRC.ComputeCRC(m_raw.m_payload, 0);
+                _base.Header.Size = (uint)_raw.Payload.Length;
+                _base.Header.CrcData = CRC.ComputeCRC(_raw.Payload, 0);
             }
         }
 
         private void UpdateCRC(Converter converter)
         {
-            Packet header = m_base.m_header;
+            Packet header = _base.Header;
 
             //
             // The CRC for the header is computed setting the CRC field to zero and then running the CRC algorithm.
             //
-            header.m_crcHeader = 0;
-            header.m_crcHeader = CRC.ComputeCRC(converter.Serialize(header), 0);
+            header.CrcHeader = 0;
+            header.CrcHeader = CRC.ComputeCRC(converter.Serialize(header), 0);
 
-            m_raw.m_header = converter.Serialize(header);
+            _raw.Header = converter.Serialize(header);
         }
 
         internal async Task<bool> SendAsync(CancellationToken cancellationToken)
         {
 
-            DebuggerEventSource.Log.WireProtocolTxHeader(m_base.m_header.m_crcHeader
-                                                        , m_base.m_header.m_crcData
-                                                        , m_base.m_header.m_cmd
-                                                        , m_base.m_header.m_flags
-                                                        , m_base.m_header.m_seq
-                                                        , m_base.m_header.m_seqReply
-                                                        , m_base.m_header.m_size
+            DebuggerEventSource.Log.WireProtocolTxHeader(_base.Header.CrcHeader
+                                                        , _base.Header.CrcData
+                                                        , _base.Header.Cmd
+                                                        , _base.Header.Flags
+                                                        , _base.Header.Seq
+                                                        , _base.Header.SeqReply
+                                                        , _base.Header.Size
                                                         );
 
-            return await m_parent.QueueOutputAsync(m_raw, cancellationToken);
+            return await _parent.QueueOutputAsync(_raw, cancellationToken);
         }
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Packet.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Packet.cs
@@ -8,18 +8,18 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 {
     public class Packet
     {
-        public static string MARKER_DEBUGGER_V1 = "MSdbgV1\0"; // Used to identify the debugger at boot time.
-        public static string MARKER_PACKET_V1 = "MSpktV1\0"; // Used to identify the start of a packet.
+        public static string MARKER_DEBUGGER_V1 = "NFDBGV1\0"; // Used to identify the debugger at boot time.
+        public static string MARKER_PACKET_V1 = "NFPKTV1\0"; // Used to identify the start of a packet.
         public const int SIZE_OF_SIGNATURE = 8;
 
-        public byte[] m_signature = new byte[SIZE_OF_SIGNATURE];
-        public uint m_crcHeader = 0;
-        public uint m_crcData = 0;
+        public byte[] Signature = new byte[SIZE_OF_SIGNATURE];
+        public uint CrcHeader = 0;
+        public uint CrcData = 0;
 
-        public uint m_cmd = 0;
-        public ushort m_seq = 0;
-        public ushort m_seqReply = 0;
-        public uint m_flags = 0;
-        public uint m_size = 0;
+        public uint Cmd = 0;
+        public ushort Seq = 0;
+        public ushort SeqReply = 0;
+        public uint Flags = 0;
+        public uint Size = 0;
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Request.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Request.cs
@@ -56,8 +56,8 @@ namespace nanoFramework.Tools.Debugger
             Packet headerReq = outgoingMsg.Header;
             Packet headerRes = res.Header;
 
-            if (headerReq.m_cmd == headerRes.m_cmd &&
-               headerReq.m_seq == headerRes.m_seqReply)
+            if (headerReq.Cmd == headerRes.Cmd &&
+               headerReq.Seq == headerRes.SeqReply)
             {
                 return true;
             }
@@ -140,7 +140,7 @@ namespace nanoFramework.Tools.Debugger
                 if (await outgoingMsg.SendAsync(cTSource.Token.AddTimeout(waitRetryTimeout)).ConfigureAwait(false))
                 {
                     // if this request is for a reboot, we won't be able to receive the reply right away because the device is rebooting
-                    if((outgoingMsg.Header.m_cmd == Commands.c_Monitor_Reboot) && retryCounter == 1)
+                    if((outgoingMsg.Header.Cmd == Commands.c_Monitor_Reboot) && retryCounter == 1)
                     {
                         // wait here for 
                         Task.Delay(2000).Wait();

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/nanoFramework.Tools.DebugLibrary.Net.projitems
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/nanoFramework.Tools.DebugLibrary.Net.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Exceptions\CouldntOpenNanoFrameworkDeviceException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Exceptions\DebugSessionAlreadyOpenException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CancellationTokenExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\DebuggerExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\DeviceInformationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\OutputExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\TypeExtensions.cs" />


### PR DESCRIPTION
- rename command for clarity and compliance with coding standards
- rename several fields and variables to comply with coding standards
- add class providing DebugEngine extensions
- add IsDeviceInInitializeStateAsync to DebugEngine extensions
- rework WFP test app
- rename MARKER_DEBUGGER_V1 and MARKER_PACKET_V1 to follow nanoFramework naming
- rework ResolveAssemblyAsync and ResolveAllAssembliesAsync
- remove unused flags enumeration from DebuggingResolveAssembly.Reply

Signed-off-by: José Simões <jose.simoes@eclo.solutions>