### PR TITLE
Revert removal of assembly deployment flags

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
@@ -16,7 +16,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <PackageId>nanoFramework.Tools.Debugger.Net</PackageId>
-    <PackageVersion>0.4.0-preview009</PackageVersion>
+    <PackageVersion>0.4.0-preview010</PackageVersion>
     <Description>This .NET library provides a debug client for nanoFramework devices using USB or Serial connection to a board.</Description>
     <Authors>nanoFramework project contributors</Authors>
     <Title>nanoFramework debug library for .NET</Title>

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -1162,6 +1162,22 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 }
             }
 
+            /// <summary>
+            /// Resolved status for a deployed assembly.
+            /// </summary>
+            [Flags]
+            public enum ResolvedStatus
+            {
+                //////////////////////////////////////////////////////////////////////////////////////////
+                // NEED TO KEEP THESE IN SYNC WITH native 'CLR_RT_Assembly' struct in nanoCLR_Runtime.h //
+                //////////////////////////////////////////////////////////////////////////////////////////
+                Resolved = 0x00000001,
+                Patched = 0x00000002,
+                PreparedForExecution = 0x00000004,
+                Deployed = 0x00000008,
+                PreparingForExecution = 0x00000010,
+            }
+
             public class Reply
             {
                 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/source/nanoFramework.Tools.DebugLibrary.UWP/nanoFramework.Tools.DebugLibrary.UWP.csproj
+++ b/source/nanoFramework.Tools.DebugLibrary.UWP/nanoFramework.Tools.DebugLibrary.UWP.csproj
@@ -17,7 +17,7 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <PackageId>nanoFramework.Tools.Debugger.UWP</PackageId>
-    <PackageVersion>0.4.0-preview009</PackageVersion>
+    <PackageVersion>0.4.0-preview010</PackageVersion>
     <Description>This UWP library provides a debug client for nanoFramework devices using USB or Serial connection to a board.</Description>
     <Authors>nanoFramework project contributors</Authors>
     <Title>nanoFramework debug library for UWP</Title>


### PR DESCRIPTION
- add back flags for assembly deployment status (now are Enum)
- bumped Nuget version to 0.4.0-preview010

Signed-off-by: José Simões <jose.simoes@eclo.solutions>