### PR TITLE
Fix bug with deployment blob building

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
@@ -16,7 +16,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <PackageId>nanoFramework.Tools.Debugger.Net</PackageId>
-    <PackageVersion>0.4.0-preview014</PackageVersion>
+    <PackageVersion>0.4.0-preview015</PackageVersion>
     <Description>This .NET library provides a debug client for nanoFramework devices using USB or Serial connection to a board.</Description>
     <Authors>nanoFramework project contributors</Authors>
     <Title>nanoFramework debug library for .NET</Title>

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -2056,7 +2056,8 @@ namespace nanoFramework.Tools.Debugger
                 int deployLength = assemblies.Sum(a => a.Length);
 
                 // build the deployment blob from the flash sector map
-                var deploymentBlob = flashSectorMap.Select(s => s.ToDeploymentSector()).ToList();
+                // apply a filter so that we take only the blocks flag for deployment 
+                var deploymentBlob = flashSectorMap.Where(s => ((s.m_flags & Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_MASK) == Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_DEPLOYMENT)).Select(s => s.ToDeploymentSector()).ToList();
 
                 while (assemblies.Count > 0)
                 {

--- a/source/nanoFramework.Tools.DebugLibrary.UWP/nanoFramework.Tools.DebugLibrary.UWP.csproj
+++ b/source/nanoFramework.Tools.DebugLibrary.UWP/nanoFramework.Tools.DebugLibrary.UWP.csproj
@@ -17,7 +17,7 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <PackageId>nanoFramework.Tools.Debugger.UWP</PackageId>
-    <PackageVersion>0.4.0-preview014</PackageVersion>
+    <PackageVersion>0.4.0-preview015</PackageVersion>
     <Description>This UWP library provides a debug client for nanoFramework devices using USB or Serial connection to a board.</Description>
     <Authors>nanoFramework project contributors</Authors>
     <Title>nanoFramework debug library for UWP</Title>


### PR DESCRIPTION
- was missing a filter to get only the blocks available for deployment
- bump Nuget version to 0.4.0-preview015

Signed-off-by: José Simões <jose.simoes@eclo.solutions>