### PR TITLE
Fix erase memory command

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml
+++ b/source/USB Test App WPF/MainWindow.xaml
@@ -31,6 +31,7 @@
         <Button Content="Resolve Assemblies" HorizontalAlignment="Left" Margin="39,235,0,0" VerticalAlignment="Top" Width="75" Click="ResolveAssembliesButton_Click" />
         <Button Content="Deploy Test" HorizontalAlignment="Left" Margin="154,235,0,0" VerticalAlignment="Top" Width="75" Click="DeployTestButton_Click" />
         <Button Content="Flash Map" HorizontalAlignment="Left" Margin="39,275,0,0" VerticalAlignment="Top" Width="75" Click="FlashMapButton_Click" />
+        <Button Content="Resume Execution" HorizontalAlignment="Left" Margin="155,275,0,0" VerticalAlignment="Top" Width="75" Click="ResumeExecutionButton_Click" />
 
 
     </Grid>

--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -179,7 +179,7 @@ namespace Serial_Test_App_WPF
             try
             {
                 // add mscorlib
-                string assemblyPath = @"..\..\..\packages\nanoFramework.CoreLibrary.1.0.0-preview020\lib\mscorlib.pe";
+                string assemblyPath = @"..\..\..\packages\nanoFramework.CoreLibrary.1.0.0-preview022\lib\mscorlib.pe";
 
                 using (FileStream fs = File.Open(assemblyPath, FileMode.Open, FileAccess.Read))
                 {
@@ -226,6 +226,36 @@ namespace Serial_Test_App_WPF
                     Debug.WriteLine("");
                     Debug.WriteLine("");
                     Debug.WriteLine(fm.ToStringForOutput());
+                    Debug.WriteLine("");
+                    Debug.WriteLine("");
+
+                }));
+            }
+            catch (Exception ex)
+            {
+
+            }
+
+            // enable button
+            (sender as Button).IsEnabled = true;
+        }
+        private async void ResumeExecutionButton_Click(object sender, RoutedEventArgs e)
+        {  
+            // disable button
+            (sender as Button).IsEnabled = false;
+
+            try
+            {
+                await Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(async () =>
+                {
+                    // enable button
+                    (sender as Button).IsEnabled = true;
+
+                    var result = await (DataContext as MainViewModel).AvailableDevices[0].DebugEngine.ResumeExecutionAsync();
+
+                    Debug.WriteLine("");
+                    Debug.WriteLine("");
+                    Debug.WriteLine($"resume execution: {result}");
                     Debug.WriteLine("");
                     Debug.WriteLine("");
 

--- a/source/USB Test App WPF/packages.config
+++ b/source/USB Test App WPF/packages.config
@@ -7,5 +7,5 @@
   <package id="PropertyChanged.Fody" version="2.1.2" targetFramework="net46" developmentDependency="true" />
   <package id="PropertyChanging.Fody" version="1.28.0" targetFramework="net462" developmentDependency="true" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net46" />
-  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview020" targetFramework="net46" />
+  <package id="nanoFramework.CoreLibrary" version="1.0.0-preview022" targetFramework="net46" />
 </packages>

--- a/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
@@ -16,7 +16,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <PackageId>nanoFramework.Tools.Debugger.Net</PackageId>
-    <PackageVersion>0.4.0-preview016</PackageVersion>
+    <PackageVersion>0.4.0-preview017</PackageVersion>
     <Description>This .NET library provides a debug client for nanoFramework devices using USB or Serial connection to a board.</Description>
     <Authors>nanoFramework project contributors</Authors>
     <Title>nanoFramework debug library for .NET</Title>

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/MessageReassembler.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/MessageReassembler.cs
@@ -74,7 +74,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
                         Debug.WriteLine("cancel token");
 
-                        return null;
+                        return GetCompleteMessage();
                     }
 
                     switch (_state)
@@ -207,7 +207,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                                 // FIXME 
                                 // evaluate the purpose of this reply back to the NanoFramework device, the nanoCLR doesn't seem to have to handle this. In the end it looks like this does have any real purpose and will only be wasting CPU.
                                 //await IncomingMessage.ReplyBadPacketAsync(m_parent, Flags.c_BadHeader);
-                                return null;
+                                return GetCompleteMessage();
                             }
 
                             break;
@@ -286,7 +286,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                                 // FIXME 
                                 // evaluate the purpose of this reply back to the NanoFramework device, the nanoCLR doesn't seem to have to handle this. In the end it looks like this does have any real purpose and will only be wasting CPU.
                                 await IncomingMessage.ReplyBadPacketAsync(_parent, Flags.c_BadPayload, cancellationToken);
-                                return null;
+                                return GetCompleteMessage();
                             }
 
                             break;
@@ -302,7 +302,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             }
 
             Debug.WriteLine("??????? leaving reassembler");
-            return null;
+            return GetCompleteMessage();
         }
 
         private int ValidMarker(byte[] marker)

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Request.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Request.cs
@@ -179,7 +179,7 @@ namespace nanoFramework.Tools.Debugger
 
             Debug.WriteLine($"Performing request exceeded attempts count...");
 
-            return null;
+            return reply;
         }
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.UWP/nanoFramework.Tools.DebugLibrary.UWP.csproj
+++ b/source/nanoFramework.Tools.DebugLibrary.UWP/nanoFramework.Tools.DebugLibrary.UWP.csproj
@@ -17,7 +17,7 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <PackageId>nanoFramework.Tools.Debugger.UWP</PackageId>
-    <PackageVersion>0.4.0-preview016</PackageVersion>
+    <PackageVersion>0.4.0-preview017</PackageVersion>
     <Description>This UWP library provides a debug client for nanoFramework devices using USB or Serial connection to a board.</Description>
     <Authors>nanoFramework project contributors</Authors>
     <Title>nanoFramework debug library for UWP</Title>


### PR DESCRIPTION
- improve ProcessMessage so the return is never null
- improve PerformRequestAsync so the return is never null
- improve code in EraseMemoryAsync to check for bad execution
- replace timeout values with constants in EraseMemoryAsync for clarity
- fix nanoframework/nf-Visual-Studio-extension/#107
- bump Nuget version to 0.4.0-preview017

Signed-off-by: José Simões <jose.simoes@eclo.solutions>