### PR TITLE
Improve detection of nanoFramework devices

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -167,11 +167,8 @@ namespace nanoFramework.Tools.Debugger
 
                     IncomingMessage msg = await PerformRequestAsync(Commands.c_Monitor_Ping, Flags.c_NoCaching, cmd, retries, timeout);
 
-                    if (msg == null)
+                    if (msg.Payload == null)
                     {
-                        // disconnect device
-                        Device.Disconnect();
-
                         // update flag
                         IsConnected = false;
 
@@ -214,9 +211,6 @@ namespace nanoFramework.Tools.Debugger
 
             if (connectionSource != ConnectionSource.Unknown && connectionSource != ConnectionSource)
             {
-                // disconnect device
-                Device.Disconnect();
-
                 // update flag
                 IsConnected = false;
 


### PR DESCRIPTION
- improve code on connectAsync (was wrongly trying to disconnect devices on error which was causing a race condition)
- STLink ports are now being checked for valid nanoFramework devices behind it (to account for boards that are making use of the Virtual COM port provided by the ST Link interface)
- fixes #40

Signed-off-by: José Simões <jose.simoes@eclo.solutions>