### PR TITLE
Fix wrong return value on SetExecutionModeAsync

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.23.{build}
+version: 0.25.{build}
 
 pull_requests:
   do_not_increment_build_number: true

--- a/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
@@ -16,7 +16,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <PackageId>nanoFramework.Tools.Debugger.Net</PackageId>
-    <PackageVersion>0.4.0-preview024</PackageVersion>
+    <PackageVersion>0.4.0-preview025</PackageVersion>
     <Description>This .NET library provides a debug client for nanoFramework devices using USB or Serial connection to a board.</Description>
     <Authors>nanoFramework project contributors</Authors>
     <Title>nanoFramework debug library for .NET</Title>

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -247,7 +247,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
                 public void PrepareForDeserialize(int size, byte[] data, Converter converter)
                 {
-                    int num = (size - 4) / (3 * 4);  // size - sizof(m_count) divided by size of deplpoymentdata struct (3*sizeof(uint))
+                    int num = (size - 4) / (3 * 4);  // size - sizof(m_count) divided by size of deployment data struct (3*sizeof(uint))
 
                     m_map = Enumerable.Range(0, num).Select(x => new DeploymentData()).ToList();
 

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -753,7 +753,7 @@ namespace nanoFramework.Tools.Debugger
                 }
                 else
                 {
-                    return (0, true);
+                    return (0, false);
                 }
             }
 

--- a/source/nanoFramework.Tools.DebugLibrary.UWP/nanoFramework.Tools.DebugLibrary.UWP.csproj
+++ b/source/nanoFramework.Tools.DebugLibrary.UWP/nanoFramework.Tools.DebugLibrary.UWP.csproj
@@ -17,7 +17,7 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <PackageId>nanoFramework.Tools.Debugger.UWP</PackageId>
-    <PackageVersion>0.4.0-preview024</PackageVersion>
+    <PackageVersion>0.4.0-preview025</PackageVersion>
     <Description>This UWP library provides a debug client for nanoFramework devices using USB or Serial connection to a board.</Description>
     <Authors>nanoFramework project contributors</Authors>
     <Title>nanoFramework debug library for UWP</Title>


### PR DESCRIPTION
## Description
- Fixed wrong return value on SetExecutionModeAsync().
- Also fixed comment typo.
- Bump NuGet to v0.4.0-preview025.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
