### PR TITLE
Rework device watcher

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -70,7 +70,6 @@ namespace Serial_Test_App_WPF
 
             // enable button
             (sender as Button).IsEnabled = true;
-
         }
 
         private object await(MainViewModel mainViewModel)

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDevice.cs
@@ -23,20 +23,6 @@ namespace nanoFramework.Tools.Debugger
             {
                 Transport = TransportType.Usb;
             }
-
-            SuicideTimer = new Timer((state) =>
-            {
-                Task.Factory.StartNew(() => 
-                {
-                    // set kill flag
-                    KillFlag = true;
-
-                    DebugEngine.Dispose();
-
-                    Dispose(false);
-                });
-
-            }, null, Timeout.Infinite, Timeout.Infinite);
         }
 
         #region Disposable implementation

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
@@ -45,11 +45,6 @@ namespace nanoFramework.Tools.Debugger
         /// </summary>
         public INanoFrameworkDeviceInfo DeviceInfo { get; internal set; }
 
-        public bool KillFlag { get; protected set; } = false;
-
-        // timer to "suicide" NanoFramework device after the hardware instance has been removed or detected as inactive by the port where it was connected
-        protected Timer SuicideTimer;
-
         private object m_serverCert = null;
         private Dictionary<uint, string> m_execSrecHash = new Dictionary<uint, string>();
         private Dictionary<uint, int> m_srecHash = new Dictionary<uint, int>();
@@ -82,31 +77,6 @@ namespace nanoFramework.Tools.Debugger
         }
 
         public object OnProgress { get; private set; }
-
-        /// <summary>
-        /// Start count down to dispose NanoFramework device. The dispose will occur after 2 seconds.
-        /// </summary>
-        public void StartCountdownForDispose()
-        {
-            StartCountdownForDispose(TimeSpan.FromSeconds(2));
-        }
-
-        /// <summary>
-        /// Start count down to dispose NanoFramework device. The dispose will occur after the timeToDispose argument is elapsed.
-        /// </summary>
-        /// <param name="timeToDispose">Time to wait before the device is disposed</param>
-        public void StartCountdownForDispose(TimeSpan timeToDispose)
-        {
-            SuicideTimer.Change(timeToDispose, TimeSpan.FromMilliseconds(-1));
-        }
-
-        /// <summary>
-        /// Stop the dispose countdown.
-        /// </summary>
-        public void StopCountdownForDispose()
-        {
-            SuicideTimer.Change(Timeout.Infinite, Timeout.Infinite);
-        }
 
         /// <summary>
         /// Get <see cref="INanoFrameworkDeviceInfo"/> from device.

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
@@ -278,12 +278,6 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                         newNanoFrameworkDevice.Dispose();
                     }
                 }
-                else
-                {
-                    // this NanoFramework device is already on the list
-                    // stop the dispose countdown!
-                    nanoFrameworkDeviceMatch.StopCountdownForDispose();
-                }
             }
         }
 
@@ -296,32 +290,50 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
             SerialDevices.Remove(deviceEntry);
 
-            // start thread to dispose and remove device from collection if it doesn't enumerate again in 2 seconds
-            Task.Factory.StartNew(() =>
-            {
-                // get device
-                var device = FindNanoFrameworkDevice(deviceId);
+            // get device
+            var device = FindNanoFrameworkDevice(deviceId);
+            // yes, remove it from collection
+            NanoFrameworkDevices.Remove(device);
 
-                if (device != null)
-                {
-                    // set device to dispose if it doesn't come back in 2 seconds
-                    device.StartCountdownForDispose();
+            device = null;
 
-                    // hold here for the same time as the default timer of the dispose timer
-                    new ManualResetEvent(false).WaitOne(TimeSpan.FromSeconds(2.5));
+            //// start thread to dispose and remove device from collection if it doesn't enumerate again in 2 seconds
+            //Task.Factory.StartNew(() =>
+            //{
+            //    // get device
+            //    var device = FindNanoFrameworkDevice(deviceId);
 
-                    // check is object was disposed
-                    if ((device as NanoDevice<NanoSerialDevice>).KillFlag)
-                    {
-                        // yes, remove it from collection
-                        NanoFrameworkDevices.Remove(device);
+            //    if (device != null)
+            //    {
+            //        // set device to dispose if it doesn't come back in 2.5 seconds
+            //        device.StartCountdownForDispose();
 
-                        Debug.WriteLine("Removing device " + device.Description);
+            //        // hold here for the same time as the default timer of the dispose timer
+            //        new ManualResetEvent(false).WaitOne(TimeSpan.FromSeconds(4));
 
-                        device = null;
-                    }
-                }
-            });
+
+            //        // try to find device
+            //        var newDevice = FindNanoFrameworkDevice(deviceId);
+
+
+            //        // check is object was disposed
+            //        if ((newDevice as NanoDevice<NanoSerialDevice>).KillFlag)
+            //        {
+            //            // yes, remove it from collection
+            //            NanoFrameworkDevices.Remove(newDevice);
+
+            //            Debug.WriteLine("Removing device " + newDevice.Description);
+
+            //            newDevice = null;
+            //        }
+            //        else
+            //        {
+            //            // add it again to serial devices collection
+            //            deviceEntry = FindDevice(deviceId);
+            //            SerialDevices.Add(deviceEntry);
+            //        }
+            //    }
+            //});
         }
 
         private void ClearDeviceEntries()
@@ -411,7 +423,6 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                         {
                             // mark this device for removal
                             devicesToRemove.Add(device);
-                            device.StartCountdownForDispose();
                         }
                         else
                         {

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortUSB/UsbPort.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortUSB/UsbPort.cs
@@ -257,13 +257,6 @@ namespace nanoFramework.Tools.Debugger.Usb
                 else
                 {
                     // this NanoFramework device is already on the list
-                    // stop the dispose countdown!
-                    nanoFrameworkDeviceMatch.StopCountdownForDispose();
-
-                    // set port parent
-                    //(mfDeviceMatch as MFDevice<MFUsbDevice>).Device.Parent = this;
-                    //// instantiate a debug engine
-                    //(mfDeviceMatch as MFDevice<MFUsbDevice>).Device.DebugEngine = new Engine(this, (mfDeviceMatch as MFDevice<MFUsbDevice>));
                 }
             }
         }
@@ -276,33 +269,11 @@ namespace nanoFramework.Tools.Debugger.Usb
             Debug.WriteLine("USB device removed: " + deviceId);
 
             UsbDevices.Remove(deviceEntry);
-
-            // start thread to dispose and remove device from collection if it doesn't enumerate again in 2 seconds
-            Task.Factory.StartNew(() =>
-            {
-                // get device
-                var device = FindNanoFrameworkDevice(deviceId);
-
-                if (device != null)
-                {
-                    // set device to dispose if it doesn't come back in 2 seconds
-                    device.StartCountdownForDispose();
-
-                    // hold here for the same time as the default timer of the dispose timer
-                    new ManualResetEvent(false).WaitOne(TimeSpan.FromSeconds(2.5));
-
-                    // check is object was disposed
-                    if((device as NanoDevice<NanoUsbDevice>).KillFlag)
-                    {
-                        // yes, remove it from collection
-                        NanoFrameworkDevices.Remove(device);
-
-                        Debug.WriteLine("Removing device " + device.Description);
-
-                        device = null;
-                    }
-                }
-            });
+            // get device
+            var device = FindNanoFrameworkDevice(deviceId);
+            // yes, remove it from collection
+            NanoFrameworkDevices.Remove(device);
+            device = null;
         }
 
         private void ClearDeviceEntries()

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -693,23 +693,16 @@ namespace nanoFramework.Tools.Debugger
 
                 await PerformRequestAsync(Commands.c_Monitor_Reboot, Flags.c_NoCaching, cmd, 0, 100);
 
-                if (option != RebootOption.NoReconnect)
+                // need to disconnect from the device if this is normal reboot
+                if ((cmd.m_flags & Commands.Monitor_Reboot.c_NormalReboot) == Commands.Monitor_Reboot.c_NormalReboot)
                 {
-                    //int timeout = 1000;
-
-                    //if (m_portDefinition is PortDefinition_Tcp)
-                    //{
-                    //    timeout = 2000;
-                    //}
-
-                    //Thread.Sleep(timeout);
+                    Device.Disconnect();
                 }
             }
             finally
             {
                 m_fThrowOnCommunicationFailure = fThrowOnCommunicationFailureSav;
             }
-
         }
 
         public async Task<bool> ReconnectAsync(bool fSoftReboot)

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/RebootOption.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/RebootOption.cs
@@ -11,7 +11,6 @@ namespace nanoFramework.Tools.Debugger
         EnterBootloader,
         RebootClrOnly,
         NormalReboot,
-        NoReconnect,
         RebootClrWaitForDebugger,
     };
 }


### PR DESCRIPTION
## Description
- Device watchers no longer use the delayed disposed and removal approach.
- Remove `NoReconnect` option from `RebootOption` because it doesn't make sense anymore.
- Add code to forcibly disconnect the device on soft reboot to allow proper watcher workflow (isn't the case if there is an open connection).

## Motivation and Context
- Current implementation of nF devices detection/connection (using device watchers) doesn't allow _reusing_ the device and the engine on device reboot because the device actually goes away and returns as a "new" one. Any reconnection mechanism required has to be implemented at the caller layer.
- Solves the critical reconnection issues that have been plaguing the debugger.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
