### PR TITLE
Add ConfigAwait to async calls

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Net/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/PortSerial/EventHandlerForSerialDevice.cs
@@ -110,9 +110,9 @@ namespace nanoFramework.Tools.Debugger.Serial
         /// An exception may be thrown if the device could not be opened for extraordinary reasons.</returns>
         public async Task<bool> OpenDeviceAsync(DeviceInformation deviceInfo, string deviceSelector)
         {
-            await Task.Delay(250);
-
+#pragma warning disable ConfigureAwaitChecker // CAC001
             device = await SerialDevice.FromIdAsync(deviceInfo.Id);
+#pragma warning restore ConfigureAwaitChecker // CAC001
 
             bool successfullyOpenedDevice = false;
 

--- a/source/nanoFramework.Tools.DebugLibrary.Net/PortUsb/EventHandlerForUsbDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/PortUsb/EventHandlerForUsbDevice.cs
@@ -27,10 +27,10 @@ namespace nanoFramework.Tools.Debugger.Usb
         /// </summary>
         private void RegisterForDeviceAccessStatusChange()
         {
-            deviceAccessInformation = DeviceAccessInformation.CreateFromId(deviceInformation.Id);
+            //deviceAccessInformation = DeviceAccessInformation.CreateFromId(deviceInformation.Id);
 
-            deviceAccessEventHandler = new TypedEventHandler<DeviceAccessInformation, DeviceAccessChangedEventArgs>(OnDeviceAccessChanged);
-            deviceAccessInformation.AccessChanged += deviceAccessEventHandler;
+            //deviceAccessEventHandler = new TypedEventHandler<DeviceAccessInformation, DeviceAccessChangedEventArgs>(OnDeviceAccessChanged);
+            //deviceAccessInformation.AccessChanged += deviceAccessEventHandler;
         }
 
         /// <summary>
@@ -48,7 +48,9 @@ namespace nanoFramework.Tools.Debugger.Usb
         /// An exception may be thrown if the device could not be opened for extraordinary reasons.</returns>
         public async Task<bool> OpenDeviceAsync(DeviceInformation deviceInfo, String deviceSelector)
         {
+#pragma warning disable ConfigureAwaitChecker // CAC001
             device = await Windows.Devices.Usb.UsbDevice.FromIdAsync(deviceInfo.Id);
+#pragma warning restore ConfigureAwaitChecker // CAC001
 
             bool successfullyOpenedDevice = false;
 

--- a/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
@@ -84,6 +84,7 @@ For UWP look for the respective Nuget package.</PackageReleaseNotes>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\packages\ConfigureAwaitChecker.Analyzer.1.0.0\analyzers\dotnet\cs\ConfigureAwaitChecker.dll" />
     <Analyzer Include="..\packages\UwpDesktop.10.0.14393.3\analyzers\dotnet\UwpDesktopAnalyzer.dll" />
   </ItemGroup>
   <Import Project="..\nanoFramework.Tools.DebugLibrary.Shared\nanoFramework.Tools.DebugLibrary.Net.projitems" Label="Shared" />

--- a/source/nanoFramework.Tools.DebugLibrary.Net/packages.config
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ConfigureAwaitChecker.Analyzer" version="1.0.0" targetFramework="net46" developmentDependency="true" />
   <package id="NuGet.Build.Packaging" version="0.2.0" targetFramework="net46" developmentDependency="true" />
   <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net46" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/Extensions/DebuggerExtensions.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/Extensions/DebuggerExtensions.cs
@@ -16,7 +16,7 @@ namespace nanoFramework.Tools.Debugger.Extensions
         /// <returns></returns>
         public static async Task<bool> IsDeviceInInitializeStateAsync(this Engine debugEngine)
         {
-            var result = await debugEngine.SetExecutionModeAsync(0, 0);
+            var result = await debugEngine.SetExecutionModeAsync(0, 0).ConfigureAwait(false);
 
             if (result.success)
             {

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/NanoFrameworkDeviceInfo.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/NanoFrameworkDeviceInfo.cs
@@ -36,10 +36,10 @@ namespace nanoFramework.Tools.Debugger
             if (!Dbg.IsConnectedTonanoCLR) return false;
 
             // get app domains from device
-            await GetAppDomainsAsync(cancelTSource.Token);
+            await GetAppDomainsAsync(cancelTSource.Token).ConfigureAwait(false);
 
             // get assemblies from device
-            await GetAssembliesAsync(cancelTSource.Token);
+            await GetAssembliesAsync(cancelTSource.Token).ConfigureAwait(false);
 
             Valid = true;
 
@@ -50,14 +50,14 @@ namespace nanoFramework.Tools.Debugger
         {
             if (Dbg.Capabilities.AppDomains)
             {
-                Commands.Debugging_TypeSys_AppDomains.Reply domainsReply = await Dbg.GetAppDomainsAsync();
+                Commands.Debugging_TypeSys_AppDomains.Reply domainsReply = await Dbg.GetAppDomainsAsync().ConfigureAwait(false);
                 // TODO add cancellation token code
 
                 if (domainsReply != null)
                 {
                     foreach (uint id in domainsReply.Data)
                     {
-                        Commands.Debugging_Resolve_AppDomain.Reply reply = await Dbg.ResolveAppDomainAsync(id);
+                        Commands.Debugging_Resolve_AppDomain.Reply reply = await Dbg.ResolveAppDomainAsync(id).ConfigureAwait(false);
                         // TODO add cancellation token code
                         if (reply != null)
                         {
@@ -70,7 +70,7 @@ namespace nanoFramework.Tools.Debugger
 
         private async Task GetAssembliesAsync(CancellationToken cancellationToken)
         {
-            List<Commands.DebuggingResolveAssembly> reply = await Dbg.ResolveAllAssembliesAsync(cancellationToken);
+            List<Commands.DebuggingResolveAssembly> reply = await Dbg.ResolveAllAssembliesAsync(cancellationToken).ConfigureAwait(false);
 
             if (reply != null)
                 foreach (Commands.DebuggingResolveAssembly resolvedAssm in reply)

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDevice.cs
@@ -74,11 +74,11 @@ namespace nanoFramework.Tools.Debugger
         {
             if (Device is NanoUsbDevice)
             {
-                return await Parent.ConnectDeviceAsync(this as NanoDeviceBase);
+                return await Parent.ConnectDeviceAsync(this as NanoDeviceBase).ConfigureAwait(false);
             }
             else if (Device is NanoSerialDevice)
             {
-                return await Parent.ConnectDeviceAsync(this as NanoDeviceBase);
+                return await Parent.ConnectDeviceAsync(this as NanoDeviceBase).ConfigureAwait(false);
             }
 
             return false;

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
@@ -248,11 +248,11 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                     if (isAllDevicesEnumerated)
                     {
                         // try opening the device to check for a valid nanoFramework device
-                        if (await ConnectSerialDeviceAsync(newNanoFrameworkDevice.Device.DeviceInformation))
+                        if (await ConnectSerialDeviceAsync(newNanoFrameworkDevice.Device.DeviceInformation).ConfigureAwait(false))
                         {
                             Debug.WriteLine("New Serial device: " + deviceInformation.Id);
 
-                            if(await CheckValidNanoFrameworkSerialDeviceAsync())
+                            if(await CheckValidNanoFrameworkSerialDeviceAsync().ConfigureAwait(false))
                             {
                                 // done here, close the device
                                 EventHandlerForSerialDevice.Current.CloseDevice();
@@ -473,7 +473,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                 var device = FindNanoFrameworkDevice(EventHandlerForSerialDevice.Current.DeviceInformation.Id);
 
                 // need an extra check on this because this can be 'just' a regular COM port without any nanoFramework device behind
-                var connectionResult = await device.DebugEngine.ConnectAsync(1, 500, false);
+                var connectionResult = await device.DebugEngine.ConnectAsync(1, 500, false).ConfigureAwait(false);
 
                 if (connectionResult)
                 {
@@ -527,7 +527,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
             inputStreamReader = null;
             outputStreamWriter = null;
 
-            return await ConnectSerialDeviceAsync((device as NanoDevice<NanoSerialDevice>).Device.DeviceInformation as SerialDeviceInformation);
+            return await ConnectSerialDeviceAsync((device as NanoDevice<NanoSerialDevice>).Device.DeviceInformation as SerialDeviceInformation).ConfigureAwait(false);
         }
 
         private async Task<bool> ConnectSerialDeviceAsync(SerialDeviceInformation serialDeviceInfo)
@@ -548,7 +548,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
             // access the Current in EventHandlerForDevice to create a watcher for the device we are connecting to
             var isConnected = EventHandlerForSerialDevice.Current.IsDeviceConnected;
 
-            return await EventHandlerForSerialDevice.Current.OpenDeviceAsync(serialDeviceInfo.DeviceInformation, serialDeviceInfo.DeviceSelector);
+            return await EventHandlerForSerialDevice.Current.OpenDeviceAsync(serialDeviceInfo.DeviceInformation, serialDeviceInfo.DeviceSelector).ConfigureAwait(false);
         }
 
         public void DisconnectDevice(NanoDeviceBase device)
@@ -591,7 +591,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
                 // serial works as a "single channel" so we can only TX or RX, 
                 // meaning that access to the resource has to be protected with a semephore
-                await semaphore.WaitAsync();
+                await semaphore.WaitAsync().ConfigureAwait(false);
 
                 try
                 {
@@ -602,7 +602,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                     // because we have an external cancellation token and the above timeout cancellation token, need to combine both
                     Task<uint> storeAsyncTask = outputStreamWriter.StoreAsync().AsTask(cancellationToken.AddTimeout(waiTimeout));
 
-                    bytesWritten = await storeAsyncTask;
+                    bytesWritten = await storeAsyncTask.ConfigureAwait(false);
 
                     if (bytesWritten > 0)
                     {
@@ -639,7 +639,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
             {
                 // serial works as a "single channel" so we can only TX or RX, 
                 // meaning that access to the resource has to be protected with a semephore
-                await semaphore.WaitAsync();
+                await semaphore.WaitAsync().ConfigureAwait(false);
 
                 // create a stream reader with serial device InputStream, if there isn't one already
                 if (inputStreamReader == null)
@@ -654,7 +654,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                     Task<UInt32> loadAsyncTask = inputStreamReader.LoadAsync(bytesToRead).AsTask(cancellationToken.AddTimeout(waiTimeout));
 
                     // get how many bytes are available to read
-                    uint bytesRead = await loadAsyncTask;
+                    uint bytesRead = await loadAsyncTask.ConfigureAwait(false);
 
                     byte[] readBuffer = new byte[bytesToRead];
                     inputStreamReader.ReadBytes(readBuffer);

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortUSB/UsbPort.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortUSB/UsbPort.cs
@@ -233,10 +233,10 @@ namespace nanoFramework.Tools.Debugger.Usb
 
                     // now fill in the description
                     // try opening the device to read the descriptor
-                    if (await ConnectUsbDeviceAsync(newNanoFrameworkDevice.Device.DeviceInformation))
+                    if (await ConnectUsbDeviceAsync(newNanoFrameworkDevice.Device.DeviceInformation).ConfigureAwait(false))
                     {
                         // the device description format is kept to maintain backwards compatibility
-                        newNanoFrameworkDevice.Description = EventHandlerForUsbDevice.Current.DeviceInformation.Name + "_" + await GetDeviceDescriptor(5);
+                        newNanoFrameworkDevice.Description = EventHandlerForUsbDevice.Current.DeviceInformation.Name + "_" + await GetDeviceDescriptor(5).ConfigureAwait(false);
 
                         Debug.WriteLine("Add new nanoFramework device to list: " + newNanoFrameworkDevice.Description + " @ " + newNanoFrameworkDevice.Device.DeviceInformation.DeviceSelector);
 
@@ -387,7 +387,9 @@ namespace nanoFramework.Tools.Debugger.Usb
                 };
 
                 // send control to device
+#pragma warning disable ConfigureAwaitChecker // CAC001
                 IBuffer responseBuffer = await EventHandlerForUsbDevice.Current.Device.SendControlInTransferAsync(setupPacket, buffer);
+#pragma warning restore ConfigureAwaitChecker // CAC001
 
                 // read from a buffer with a data reader
                 DataReader reader = DataReader.FromBuffer(responseBuffer);
@@ -435,7 +437,7 @@ namespace nanoFramework.Tools.Debugger.Usb
 
         public async Task<bool> ConnectDeviceAsync(NanoDeviceBase device)
         {
-            return await ConnectUsbDeviceAsync((device as NanoDevice<NanoUsbDevice>).Device.DeviceInformation as UsbDeviceInformation);
+            return await ConnectUsbDeviceAsync((device as NanoDevice<NanoUsbDevice>).Device.DeviceInformation as UsbDeviceInformation).ConfigureAwait(false);
         }
 
         private async Task<bool> ConnectUsbDeviceAsync(UsbDeviceInformation usbDeviceInfo)
@@ -453,7 +455,7 @@ namespace nanoFramework.Tools.Debugger.Usb
             // Create an EventHandlerForDevice to watch for the device we are connecting to
             EventHandlerForUsbDevice.CreateNewEventHandlerForDevice();
 
-            return await EventHandlerForUsbDevice.Current.OpenDeviceAsync(usbDeviceInfo.DeviceInformation, usbDeviceInfo.DeviceSelector);
+            return await EventHandlerForUsbDevice.Current.OpenDeviceAsync(usbDeviceInfo.DeviceInformation, usbDeviceInfo.DeviceSelector).ConfigureAwait(false);
         }
 
         public void DisconnectDevice(NanoDeviceBase device)
@@ -519,7 +521,7 @@ namespace nanoFramework.Tools.Debugger.Usb
                         storeAsyncTask = writer.StoreAsync().AsTask(linkedCancelationToken);
                     }
 
-                    bytesWritten = await storeAsyncTask;
+                    bytesWritten = await storeAsyncTask.ConfigureAwait(false);
 
                     if (bytesWritten > 0)
                     {
@@ -567,7 +569,7 @@ namespace nanoFramework.Tools.Debugger.Usb
                 Task<UInt32> loadAsyncTask;
 
                 //Debug.WriteLine("### waiting");
-                await semaphore.WaitAsync();
+                await semaphore.WaitAsync().ConfigureAwait(false);
                 //Debug.WriteLine("### got it");
 
                 try
@@ -596,7 +598,9 @@ namespace nanoFramework.Tools.Debugger.Usb
                         if (readCount > 0 &&
                             bytesToRead > 0)
                         {
+#pragma warning disable ConfigureAwaitChecker // CAC001
                             await reader.LoadAsync(readCount);
+#pragma warning restore ConfigureAwaitChecker // CAC001
 
                             byte[] readBuffer = new byte[bytesToRead];
                             reader.ReadBytes(readBuffer);

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/Runtime/RunTimeValue.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/Runtime/RunTimeValue.cs
@@ -354,11 +354,11 @@ namespace nanoFramework.Tools.Debugger
 
             if (IsArrayReference)
             {
-                fRes = await m_eng.SetArrayElementAsync(m_handle.m_arrayref_referenceID, m_handle.m_arrayref_index, data);
+                fRes = await m_eng.SetArrayElementAsync(m_handle.m_arrayref_referenceID, m_handle.m_arrayref_index, data).ConfigureAwait(false);
             }
             else
             {
-                fRes = await m_eng.SetBlockAsync(m_handle.m_referenceID, dt, data);
+                fRes = await m_eng.SetBlockAsync(m_handle.m_referenceID, dt, data).ConfigureAwait(false);
             }
 
             return fRes;
@@ -375,7 +375,7 @@ namespace nanoFramework.Tools.Debugger
             // referenceIdDirect is the data pointer for the CLR_RT_HeapBlock.  We subtract 4 to point to the id 
             // portion of the heapblock.  For the second parameter we need to use the direct reference because
             // ReferenceId will return null in this case since the value has not been assigned yet.
-            return await m_eng.AssignRuntimeValueAsync(referenceIdDirect - 4, ReferenceIdDirect - 4);
+            return await m_eng.AssignRuntimeValueAsync(referenceIdDirect - 4, ReferenceIdDirect - 4).ConfigureAwait(false);
         }
 
         public async Task<RuntimeValue> AssignAsync(RuntimeValue val)
@@ -393,7 +393,7 @@ namespace nanoFramework.Tools.Debugger
                     Array.Copy(val.m_handle.m_builtinValue, data, data.Length);
                 }
 
-                if (await SetBlockAsync(dt, data))
+                if (await SetBlockAsync(dt, data).ConfigureAwait(false))
                 {
                     retval = this;
                 }
@@ -416,7 +416,7 @@ namespace nanoFramework.Tools.Debugger
                     throw new InvalidCastException("The two runtime values are incompatible");
                 }
 
-                retval = await AssignAsync(val != null ? val.ReferenceIdDirect : 0);
+                retval = await AssignAsync(val != null ? val.ReferenceIdDirect : 0).ConfigureAwait(false);
             }
 
             return retval;

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/Runtime/RuntimeValue_Array.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/Runtime/RuntimeValue_Array.cs
@@ -24,7 +24,7 @@ namespace nanoFramework.Tools.Debugger
 
         public override async Task<RuntimeValue> GetElementAsync(uint index)
         {
-            return await m_eng.GetArrayElementAsync(m_handle.m_referenceID, index);
+            return await m_eng.GetArrayElementAsync(m_handle.m_referenceID, index).ConfigureAwait(false);
         }
 
         public override uint Length { get { return m_handle.m_array_numOfElements; } }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/Runtime/RuntimeValue_Class.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/Runtime/RuntimeValue_Class.cs
@@ -32,7 +32,7 @@ namespace nanoFramework.Tools.Debugger
 
         public override async Task<RuntimeValue> GetFieldAsync(uint offset, uint fd)
         {
-            return await m_eng.GetFieldValueAsync(this, offset, fd);
+            return await m_eng.GetFieldValueAsync(this, offset, fd).ConfigureAwait(false);
         }
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/Runtime/RuntimeValue_Indirect.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/Runtime/RuntimeValue_Indirect.cs
@@ -81,17 +81,17 @@ namespace nanoFramework.Tools.Debugger
         {
             if (m_value == null) throw new NotImplementedException();
 
-            await m_value.SetStringValueAsync(val);
+            await m_value.SetStringValueAsync(val).ConfigureAwait(false);
         }
 
         public override async Task<RuntimeValue> GetFieldAsync(uint offset, uint fd)
         {
-            return (m_value == null) ? null : await m_value.GetFieldAsync(offset, fd);
+            return (m_value == null) ? null : await m_value.GetFieldAsync(offset, fd).ConfigureAwait(false);
         }
 
         public override async Task<RuntimeValue> GetElementAsync(uint index)
         {
-            return (m_value == null) ? null : await m_value.GetElementAsync(index);
+            return (m_value == null) ? null : await m_value.GetElementAsync(index).ConfigureAwait(false);
         }
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/Runtime/RuntimeValue_String.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/Runtime/RuntimeValue_String.cs
@@ -70,7 +70,7 @@ namespace nanoFramework.Tools.Debugger
                 throw new ArgumentException("String must have same length");
             }
 
-            var writeResult = await m_eng.WriteMemoryAsync(m_handle.m_charsInString, buf);
+            var writeResult = await m_eng.WriteMemoryAsync(m_handle.m_charsInString, buf).ConfigureAwait(false);
             if (writeResult.success == false)
             {
                 throw new ArgumentException("Cannot write string");

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/SRecordFile.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/SRecordFile.cs
@@ -38,9 +38,11 @@ namespace nanoFramework.Tools.Debugger
                 throw new System.IO.FileNotFoundException(String.Format("Cannot find {0}", file));
             }
 
+#pragma warning disable ConfigureAwaitChecker // CAC001
             var textLines = await FileIO.ReadLinesAsync(file);
+#pragma warning restore ConfigureAwaitChecker // CAC001
 
-            foreach(string line in textLines)
+            foreach (string line in textLines)
             {
                 int lineNum = 0;
 

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/ConnectionSource.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/ConnectionSource.cs
@@ -8,7 +8,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
     public enum ConnectionSource
     {
         Unknown = 0,
-        NanoBooter,
-        NanoCLR,
+        nanoBooter,
+        nanoCLR,
     };
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Controller.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Controller.cs
@@ -69,7 +69,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         public async Task<bool> QueueOutputAsync(MessageRaw raw, CancellationToken cancellationToken)
         {
             Debug.WriteLine("QueueOutputAsync 1");
-            await SendRawBufferAsync(raw.Header, TimeSpan.FromMilliseconds(1000), cancellationToken);
+            await SendRawBufferAsync(raw.Header, TimeSpan.FromMilliseconds(1000), cancellationToken).ConfigureAwait(false);
 
             // check for cancelation request
             if (cancellationToken.IsCancellationRequested)
@@ -83,7 +83,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             {
                 Debug.WriteLine("QueueOutputAsync 2");
 
-                await SendRawBufferAsync(raw.Payload, TimeSpan.FromMilliseconds(1000), cancellationToken);
+                await SendRawBufferAsync(raw.Payload, TimeSpan.FromMilliseconds(1000), cancellationToken).ConfigureAwait(false);
             }
 
             return true;
@@ -122,7 +122,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         {
             Debug.WriteLine("SendRawBufferAsync");
 
-            return await App.SendBufferAsync(buffer, waiTimeout, cancellationToken);
+            return await App.SendBufferAsync(buffer, waiTimeout, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task<int> ReadBufferAsync(byte[] buffer, int offset, int bytesToRead, TimeSpan waitTimeout, CancellationToken cancellationToken)
@@ -148,7 +148,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 }
 
                 // read next chunk of data async
-                var readResult = await App.ReadBufferAsync((uint)bytesToRead, waitTimeout, cancellationToken);
+                var readResult = await App.ReadBufferAsync((uint)bytesToRead, waitTimeout, cancellationToken).ConfigureAwait(false);
 
                 Debug.WriteLine("read {0} bytes", readResult.Length);
                 // any byte read?

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/IncomingMessage.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/IncomingMessage.cs
@@ -93,7 +93,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             //What is this for? Nack + Ping?  What can the nanoCLR possibly do with this information?
             OutgoingMessage msg = new OutgoingMessage(ctrl, new WireProtocol.Converter(), Commands.c_Monitor_Ping, Flags.c_NonCritical | Flags.c_NACK | flags, null);
 
-            return await msg.SendAsync(cancellationToken);
+            return await msg.SendAsync(cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<bool> ReplyAsync(Converter converter, uint flags, object payload, CancellationToken cancellationToken)
@@ -101,7 +101,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
             OutgoingMessage msgReply = new OutgoingMessage(this, converter, flags, payload);
 
-            return await msgReply.SendAsync(cancellationToken);
+            return await msgReply.SendAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/MessageReassembler.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/MessageReassembler.cs
@@ -102,7 +102,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                             // need to have a timeout to cancel the read task otherwise it may end up waiting forever for this to return
                             // because we have an external cancellation token and the above timeout cancellation token, need to combine both
 
-                            bytesRead = await _parent.ReadBufferAsync(_messageRaw.Header, _rawPos, count, request.waitRetryTimeout, cancellationToken.AddTimeout(request.waitRetryTimeout));
+                            bytesRead = await _parent.ReadBufferAsync(_messageRaw.Header, _rawPos, count, request.waitRetryTimeout, cancellationToken.AddTimeout(request.waitRetryTimeout)).ConfigureAwait(false);
 
                             _rawPos += bytesRead;
 
@@ -145,7 +145,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                             // need to have a timeout to cancel the read task otherwise it may end up waiting forever for this to return
                             // because we have an external cancellation token and the above timeout cancellation token, need to combine both
 
-                            bytesRead = await _parent.ReadBufferAsync(_messageRaw.Header, _rawPos, count, request.waitRetryTimeout, cancellationToken.AddTimeout(request.waitRetryTimeout));
+                            bytesRead = await _parent.ReadBufferAsync(_messageRaw.Header, _rawPos, count, request.waitRetryTimeout, cancellationToken.AddTimeout(request.waitRetryTimeout)).ConfigureAwait(false);
 
                             _rawPos += bytesRead;
 
@@ -220,7 +220,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                             // need to have a timeout to cancel the read task otherwise it may end up waiting forever for this to return
                             // because we have an external cancellation token and the above timeout cancellation token, need to combine both
 
-                            bytesRead = await _parent.ReadBufferAsync(_messageRaw.Payload, _rawPos, count, request.waitRetryTimeout, cancellationToken.AddTimeout(request.waitRetryTimeout));
+                            bytesRead = await _parent.ReadBufferAsync(_messageRaw.Payload, _rawPos, count, request.waitRetryTimeout, cancellationToken.AddTimeout(request.waitRetryTimeout)).ConfigureAwait(false);
 
                             _rawPos += bytesRead;
 
@@ -246,7 +246,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                                         _messageRaw.Payload = null;
                                     }
 
-                                    if (await ProcessMessage(GetCompleteMessage(), fReply, cancellationToken))
+                                    if (await ProcessMessage(GetCompleteMessage(), fReply, cancellationToken).ConfigureAwait(false))
                                     {
                                         DebuggerEventSource.Log.WireProtocolReceiveState(_state);
 
@@ -285,7 +285,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                             {
                                 // FIXME 
                                 // evaluate the purpose of this reply back to the NanoFramework device, the nanoCLR doesn't seem to have to handle this. In the end it looks like this does have any real purpose and will only be wasting CPU.
-                                await IncomingMessage.ReplyBadPacketAsync(_parent, Flags.c_BadPayload, cancellationToken);
+                                await IncomingMessage.ReplyBadPacketAsync(_parent, Flags.c_BadPayload, cancellationToken).ConfigureAwait(false);
                                 return GetCompleteMessage();
                             }
 
@@ -387,7 +387,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                             // FIXME
                             //cmdReply.m_dbg_flags = (m_stopDebuggerOnConnect ? Commands.Monitor_Ping.c_Ping_DbgFlag_Stop : 0);
 
-                            await msg.ReplyAsync(_parent.CreateConverter(), Flags.c_NonCritical, cmdReply, cancellationToken);
+                            await msg.ReplyAsync(_parent.CreateConverter(), Flags.c_NonCritical, cmdReply, cancellationToken).ConfigureAwait(false);
 
                             //m_evtPing.Set();
 

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/OutgoingMessage.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/OutgoingMessage.cs
@@ -98,7 +98,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                                                         , _base.Header.Size
                                                         );
 
-            return await _parent.QueueOutputAsync(_raw, cancellationToken);
+            return await _parent.QueueOutputAsync(_raw, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Request.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Request.cs
@@ -134,7 +134,7 @@ namespace nanoFramework.Tools.Debugger
 
                 // send message
                 // add a cancellation token to force cancel, the send 
-                if (await outgoingMsg.SendAsync(cTSource.Token))
+                if (await outgoingMsg.SendAsync(cTSource.Token).ConfigureAwait(false))
                 {
                     // if this request is for a reboot, we won't be able to receive the reply right away because the device is rebooting
                     if(outgoingMsg.Header.Cmd == Commands.c_Monitor_Reboot)
@@ -152,7 +152,7 @@ namespace nanoFramework.Tools.Debugger
                     {
                         // need to have a timeout to cancel the process task otherwise it may end up waiting forever for this to return
                         // because we have an external cancellation token and the above timeout cancellation token, need to combine both
-                        reply = await reassembler.ProcessAsync(cTSource.Token.AddTimeout(waitRetryTimeout));
+                        reply = await reassembler.ProcessAsync(cTSource.Token.AddTimeout(waitRetryTimeout)).ConfigureAwait(false);
                     }
                     catch(Exception ex)
                     {


### PR DESCRIPTION
## Description
- Add ConfigAwait to async calls.
- Rename `ConnectionSource` enum to follow project name casing
- Add Nuget package with ConfigureAwaitChecker analyser

## Motivation and Context
- Following GP on async/await patterns

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>