### PR TITLE
Stability improvements

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -36,6 +36,8 @@ namespace Serial_Test_App_WPF
 
                  bool connectResult = await (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.ConnectAsync(3, 1000, true);
 
+                 (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.Start();
+
                  var di = await (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].GetDeviceInfoAsync();
 
                  Debug.WriteLine("");


### PR DESCRIPTION


## Description
- Remove call to Start in ConnectAsync because we need to have better control over this
- Add code to check for invalid Capabilities on ConnectAsync and failing on error
- Made Engine.Start  return Task so it can be properly used as a Task
- Improve cancellation token management in Engine.Start
- Rework code to add devices to nanoDevices collection
- Rework code to ReadBufferAsync in order to prevent throwing exceptions on errors
- Update WPF test app

## Motivation and Context
- Addresses stability issues 
- Helps resolving nanoFramework/Home#247

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
