### PR TITLE
Rework SerialDevice and associated classes

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -38,11 +38,6 @@ namespace Serial_Test_App_WPF
             {
                 var device = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex];
 
-                if(device.DebugEngine == null)
-                {
-                    device.DebugEngine = new nanoFramework.Tools.Debugger.Engine(device);
-                }
-
                 bool connectResult = await device.DebugEngine.ConnectAsync(5000, true);
 
                 //(DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.Start();

--- a/source/nanoFramework.Tools.DebugLibrary.Net/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/PortSerial/EventHandlerForSerialDevice.cs
@@ -8,9 +8,6 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Windows.Devices.Enumeration;
 using Windows.Devices.SerialCommunication;
-using Windows.Foundation;
-using System.Windows;
-using Windows.UI.Xaml;
 
 namespace nanoFramework.Tools.Debugger.Serial
 {
@@ -20,10 +17,8 @@ namespace nanoFramework.Tools.Debugger.Serial
     /// </summary>
     public partial class EventHandlerForSerialDevice
     {
-        private EventHandler appSuspendEventHandler;
-        private EventHandler appResumeEventHandler;
-
-        private SuspendingEventHandler appSuspendCallback;
+        private EventHandler _appSuspendEventHandler;
+        private EventHandler _appResumeEventHandler;
 
         /// <summary>
         /// Register for app suspension/resume events. See the comments
@@ -33,21 +28,21 @@ namespace nanoFramework.Tools.Debugger.Serial
         /// </summary>
         private void RegisterForAppEvents()
         {
-            appSuspendEventHandler = new EventHandler(Current.OnAppDeactivated);
-            appResumeEventHandler = new EventHandler(Current.OnAppResume);
+            _appSuspendEventHandler = new EventHandler(Current.OnAppDeactivated);
+            _appResumeEventHandler = new EventHandler(Current.OnAppResume);
 
             // This event is raised when the app is exited and when the app is suspended
-            CallerApp.Deactivated += appSuspendEventHandler;
+            CallerApp.Deactivated += _appSuspendEventHandler;
 
-            CallerApp.Activated += appResumeEventHandler;
+            CallerApp.Activated += _appResumeEventHandler;
         }
 
         private void UnregisterFromAppEvents()
         {
             // This event is raised when the app is exited and when the app is suspended
-            CallerApp.Deactivated -= appSuspendEventHandler;
+            CallerApp.Deactivated -= _appSuspendEventHandler;
 
-            CallerApp.Activated -= appResumeEventHandler;
+            CallerApp.Activated -= _appResumeEventHandler;
         }
 
         /// <summary>
@@ -74,14 +69,14 @@ namespace nanoFramework.Tools.Debugger.Serial
         /// <param name="eventArgs"></param>
         private void OnAppDeactivated(object sender, EventArgs args)
         {
-            if (watcherStarted)
+            if (_watcherStarted)
             {
-                watcherSuspended = true;
+                _watcherSuspended = true;
                 StopDeviceWatcher();
             }
             else
             {
-                watcherSuspended = false;
+                _watcherSuspended = false;
             }
 
             //// Forward suspend event to registered callback function
@@ -106,65 +101,70 @@ namespace nanoFramework.Tools.Debugger.Serial
         /// <param name="deviceSelector">The AQS used to find this device</param>
         /// <returns>True if the device was successfully opened, false if the device could not be opened for well known reasons.
         /// An exception may be thrown if the device could not be opened for extraordinary reasons.</returns>
-        public async Task<bool> OpenDeviceAsync(DeviceInformation deviceInfo, string deviceSelector)
+        public async Task<bool> OpenDeviceAsync(DeviceInformation deviceInfo, string deviceSelector, SerialDevice existingDevice)
         {
-#pragma warning disable ConfigureAwaitChecker // CAC001
-            device = await SerialDevice.FromIdAsync(deviceInfo.Id);
-#pragma warning restore ConfigureAwaitChecker // CAC001
-
             bool successfullyOpenedDevice = false;
+
+            if (existingDevice == null)
+            {
+                _device = await SerialDevice.FromIdAsync(deviceInfo.Id);
+            }
+            else
+            {
+                _device = existingDevice;
+            }
 
             try
             {
                 // Device could have been blocked by user or the device has already been opened by another app.
-                if (device != null)
+                if (_device != null)
                 {
                     successfullyOpenedDevice = true;
 
-                    deviceInformation = deviceInfo;
-                    this.deviceSelector = deviceSelector;
+                    _deviceInformation = deviceInfo;
+                    this._deviceSelector = deviceSelector;
 
-                    Debug.WriteLine($"Device {deviceInformation.Id} opened");
+                    Debug.WriteLine($"Device {_deviceInformation.Id} opened");
 
                     // adjust settings for serial port
-                    device.BaudRate = 115200;
+                    _device.BaudRate = 115200;
 
                     /////////////////////////////////////////////////////////////
                     // need to FORCE the parity setting to _NONE_ because        
                     // the default on the current ST Link is different causing 
                     // the communication to fail
                     /////////////////////////////////////////////////////////////
-                    device.Parity = SerialParity.None;
+                    _device.Parity = SerialParity.None;
 
-                    device.WriteTimeout = TimeSpan.FromMilliseconds(1000);
-                    device.ReadTimeout = TimeSpan.FromMilliseconds(1000);
-                    device.ErrorReceived += Device_ErrorReceived;
+                    _device.WriteTimeout = TimeSpan.FromMilliseconds(1000);
+                    _device.ReadTimeout = TimeSpan.FromMilliseconds(1000);
+                    _device.ErrorReceived += Device_ErrorReceived;
 
                     // Notify registered callback handle that the device has been opened
-                    deviceConnectedCallback?.Invoke(this, deviceInformation);
+                    _deviceConnectedCallback?.Invoke(this, _deviceInformation);
 
                     // Background tasks are not part of the app, so app events will not have an affect on the device
-                    if (!isBackgroundTask && (appSuspendEventHandler == null || appResumeEventHandler == null))
+                    if (!_isBackgroundTask && (_appSuspendEventHandler == null || _appResumeEventHandler == null))
                     {
                         RegisterForAppEvents();
                     }
 
                     // User can block the device after it has been opened in the Settings charm. We can detect this by registering for the 
                     // DeviceAccessInformation.AccessChanged event
-                    if (deviceAccessEventHandler == null)
+                    if (_deviceAccessEventHandler == null)
                     {
                         RegisterForDeviceAccessStatusChange();
                     }
 
                     // Create and register device watcher events for the device to be opened unless we're reopening the device
-                    if (deviceWatcher == null)
+                    if (_deviceWatcher == null)
                     {
-                        deviceWatcher = DeviceInformation.CreateWatcher(deviceSelector);
+                        _deviceWatcher = DeviceInformation.CreateWatcher(deviceSelector);
 
                         RegisterForDeviceWatcherEvents();
                     }
 
-                    if (!watcherStarted)
+                    if (!_watcherStarted)
                     {
                         // Start the device watcher after we made sure that the device is opened.
                         StartDeviceWatcher();

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDevice.cs
@@ -6,7 +6,6 @@
 
 using nanoFramework.Tools.Debugger.WireProtocol;
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace nanoFramework.Tools.Debugger
@@ -27,7 +26,6 @@ namespace nanoFramework.Tools.Debugger
             {
                 Transport = TransportType.Serial;
             }
-
         }
 
         #region Disposable implementation

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
@@ -20,10 +20,27 @@ namespace nanoFramework.Tools.Debugger
 {
     public abstract class NanoDeviceBase
     {
+        private Engine _debugEngine;
+
+
         /// <summary>
-        /// .NETMF debug engine
+        /// nanoFramework debug engine.
         /// </summary>
-        public Engine DebugEngine { get; set; }
+        /// 
+        public Engine DebugEngine
+        {
+            get
+            { 
+                if (_debugEngine == null)
+                {
+                    _debugEngine = new Engine(this);
+                }
+
+                return _debugEngine;
+            }
+
+            set => _debugEngine = value;
+        }
 
         /// <summary>
         /// Transport to the device. 
@@ -77,6 +94,8 @@ namespace nanoFramework.Tools.Debugger
         }
 
         public object OnProgress { get; private set; }
+
+        public object DeviceBase { get; internal set; }
 
         /// <summary>
         /// Get <see cref="INanoFrameworkDeviceInfo"/> from device.

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -75,19 +75,11 @@ namespace nanoFramework.Tools.Debugger
 
         internal INanoDevice Device;
 
-        public Engine(NanoDeviceBase device)
+        internal Engine(NanoDeviceBase device)
         {
             InitializeLocal(device);
 
-            _requestsStore = new WireProtocolRequestsStore();
-
             _state.SetValue(EngineState.Value.Starting, true);
-
-            // check if cancellation token needs to be renewed
-            if (_backgroundProcessorCancellation.IsCancellationRequested)
-            {
-                _backgroundProcessorCancellation = new CancellationTokenSource();
-            }
 
             // start task to process background messages
             _backgroundProcessor = Task.Factory.StartNew(() => ProcessIncomingMessages(), _backgroundProcessorCancellation.Token, TaskCreationOptions.LongRunning, TaskScheduler.Current);
@@ -251,6 +243,8 @@ namespace nanoFramework.Tools.Debugger
 
             while (!_backgroundProcessorCancellation.IsCancellationRequested && _state.IsRunning)
             {
+                await Device.ConnectAsync();
+
                 try
                 {
                     await reassembler.ProcessAsync(_backgroundProcessorCancellation.Token);

--- a/source/nanoFramework.Tools.DebugLibrary.UWP/PortSerial/SerialPort.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.UWP/PortSerial/SerialPort.cs
@@ -27,9 +27,9 @@ namespace nanoFramework.Tools.Debugger.PortSerial
         /// </summary>
         public SerialPort(Application callerApp)
         {
-            mapDeviceWatchersToDeviceSelector = new Dictionary<DeviceWatcher, String>();
+            _mapDeviceWatchersToDeviceSelector = new Dictionary<DeviceWatcher, String>();
             NanoFrameworkDevices = new ObservableCollection<NanoDeviceBase>();
-            SerialDevices = new List<Serial.SerialDeviceInformation>();
+            _serialDevices = new List<Serial.SerialDeviceInformation>();
 
             // set caller app property
             EventHandlerForSerialDevice.CallerApp = callerApp;


### PR DESCRIPTION
## Description
- Rework SerialDevice and event handlers to really reuse SerialDevice (UWP API doesn't like to open/close serial devices)
- SerialDevice DataWriter and DataReader are now local to methods that use them
- SerialDevice close doesn't dispose device watchers and event handlers anymore
- Remove unused #pragma warnigns
- Engine constructor is now internal
- ProcessIncomingMessages now tries to connect to device before starting processor
- Rework Engine constructor to remove unnecessary initializations
- NanoDevice debugger is now created on property access
- Refactor code to follow coding guidelines
- Code clean-up
- Update WPF test app

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>


