### PR TITLE
Add cancellation with default timeout

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -418,7 +418,7 @@ namespace nanoFramework.Tools.Debugger
                 OutgoingMessage message = new OutgoingMessage(_controlller.GetNextSequenceId(), CreateConverter(), command, flags, payload);
 
                 return await PerformRequestAsync(message, _cancellationTokenSource.Token, millisecondsTimeout);
-            });
+            }, _cancellationTokenSource.Token.AddTimeout(new TimeSpan(0, 0, 0, 0, millisecondsTimeout)));
 
             return t.Result;
         }
@@ -427,7 +427,7 @@ namespace nanoFramework.Tools.Debugger
         {
             var t = Task.Run(async () => {
                 return await PerformRequestAsync(message, _cancellationTokenSource.Token, millisecondsTimeout);
-            });
+            }, _cancellationTokenSource.Token.AddTimeout(new TimeSpan(0, 0, 0, 0, millisecondsTimeout)));
 
             return t.Result;
         }


### PR DESCRIPTION
## Description
- Add cancellation with default timeout when creating Task to execute sync requests

## Motivation and Context
- This is to make sure the sync tasks are ended after a set timeout

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
