### PR TITLE
Allow ESP32 boards to work with Visual studio extension

### DIFF
--- a/source/Debug Library/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/Debug Library/PortSerial/EventHandlerForSerialDevice.cs
@@ -243,7 +243,8 @@ namespace nanoFramework.Tools.Debugger.Serial
 
                     // adjust settings for serial port
                     device.BaudRate = 115200;
-                    
+                    device.DataBits = 8;
+                   
                     /////////////////////////////////////////////////////////////
                     // need to FORCE the parity setting to _NONE_ because        
                     // the default on the current ST Link is different causing 

--- a/source/nanoFramework.Tools.DebugLibrary.Net/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/PortSerial/EventHandlerForSerialDevice.cs
@@ -129,6 +129,12 @@ namespace nanoFramework.Tools.Debugger.Serial
                     // adjust settings for serial port
                     _device.BaudRate = 115200;
                     _device.DataBits = 8;
+                    
+                    /////////////////////////////////////////////////////////////
+                    // need to FORCE the parity setting to _NONE_ because        
+                    // the default on the current ST Link is different causing 
+                    // the communication to fail
+                    /////////////////////////////////////////////////////////////
                     _device.Parity = SerialParity.None;
 
                     _device.WriteTimeout = TimeSpan.FromMilliseconds(1000);

--- a/source/nanoFramework.Tools.DebugLibrary.Net/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/PortSerial/EventHandlerForSerialDevice.cs
@@ -128,12 +128,7 @@ namespace nanoFramework.Tools.Debugger.Serial
 
                     // adjust settings for serial port
                     _device.BaudRate = 115200;
-
-                    /////////////////////////////////////////////////////////////
-                    // need to FORCE the parity setting to _NONE_ because        
-                    // the default on the current ST Link is different causing 
-                    // the communication to fail
-                    /////////////////////////////////////////////////////////////
+                    _device.DataBits = 8;
                     _device.Parity = SerialParity.None;
 
                     _device.WriteTimeout = TimeSpan.FromMilliseconds(1000);

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/EventHandlerForSerialDevice.cs
@@ -206,7 +206,7 @@ namespace nanoFramework.Tools.Debugger.Serial
 
         private void Device_ErrorReceived(SerialDevice sender, ErrorReceivedEventArgs args)
         {
-            throw new NotImplementedException();
+            //throw new NotImplementedException();
         }
 
         /// <summary>

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
@@ -441,11 +441,23 @@ namespace nanoFramework.Tools.Debugger.PortSerial
             var name = deviceInformation.DeviceInformation.Name;
             var serialNumber = GetSerialNumber(deviceInformation.DeviceInformation.Id);
 
-            // acceptable names and that are know valid nanoFramework devices
-            if (
-                // STM32 COM port on on-board ST Link found in most NUCLEO boards
-                (name == "STM32 STLink")
-               )
+            if (serialNumber != null && serialNumber.Contains("NANO_"))
+            {
+                var device = FindNanoFrameworkDevice(deviceInformation.DeviceInformation.Id);
+
+                if (device != null)
+                {
+                    device.Description = serialNumber + " @ " + device.Description;
+
+                    // should be a valid nanoFramework device, done here
+                    return true;
+                }
+                else
+                {
+                    Debug.WriteLine($"Couldn't find nano device {EventHandlerForSerialDevice.Current.DeviceInformation.Id} with serial {serialNumber}");
+                }
+            }
+            else
             {
                 // need an extra check on this because this can be 'just' a regular COM port without any nanoFramework device behind
 
@@ -470,26 +482,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                 }
 
             }
-            else if (serialNumber != null)
-            {
-                if (serialNumber.Contains("NANO_"))
-                {
-                    var device = FindNanoFrameworkDevice(deviceInformation.DeviceInformation.Id);
-
-                    if (device != null)
-                    {
-                        device.Description = serialNumber + " @ " + device.Description;
-
-                        // should be a valid nanoFramework device, done here
-                        return true;
-                    }
-                    else
-                    {
-                        Debug.WriteLine($"Couldn't find nano device {EventHandlerForSerialDevice.Current.DeviceInformation.Id} with serial {serialNumber}");
-                    }
-                }
-            }
-
+ 
             // default to false
             return false;
         }

--- a/source/nanoFramework.Tools.DebugLibrary.UWP/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.UWP/PortSerial/EventHandlerForSerialDevice.cs
@@ -153,12 +153,7 @@ namespace nanoFramework.Tools.Debugger.Serial
 
                     // adjust settings for serial port
                     _device.BaudRate = 115200;
-
-                    /////////////////////////////////////////////////////////////
-                    // need to FORCE the parity setting to _NONE_ because        
-                    // the default on the current ST Link is different causing 
-                    // the communication to fail
-                    /////////////////////////////////////////////////////////////
+					_device.DataBits = 8;
                     _device.Parity = SerialParity.None;
 
                     _device.WriteTimeout = TimeSpan.FromMilliseconds(1000);

--- a/source/nanoFramework.Tools.DebugLibrary.UWP/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.UWP/PortSerial/EventHandlerForSerialDevice.cs
@@ -154,7 +154,13 @@ namespace nanoFramework.Tools.Debugger.Serial
                     // adjust settings for serial port
                     _device.BaudRate = 115200;
 					_device.DataBits = 8;
-                    _device.Parity = SerialParity.None;
+                    
+                     /////////////////////////////////////////////////////////////
+                    // need to FORCE the parity setting to _NONE_ because        
+                    // the default on the current ST Link is different causing 
+                    // the communication to fail
+                    /////////////////////////////////////////////////////////////
+                   _device.Parity = SerialParity.None;
 
                     _device.WriteTimeout = TimeSpan.FromMilliseconds(1000);
                     _device.ReadTimeout = TimeSpan.FromMilliseconds(1000);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes to allow ESP32 boards  to work with Visual Studio extension 

## Description
<!--- Describe your changes in detail -->
The original code only allowed serial ports with the name "STM32 ST LINK" to connect, this change removes this check.  

With the ESP32 boards the serial link would default to 7 bit data but 8 bit data is required. Now it is forced to 8 bit data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Now when an ESP32 board is connected it is seen in Visual Studio.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Adrian Soundy <adriabsoundy@gmail.com>
