### PR TITLE
Rework async and sync requests

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
@@ -482,7 +482,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                 }
 
             }
- 
+
             // default to false
             return false;
         }
@@ -570,7 +570,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
         public async Task<bool> ConnectDeviceAsync(NanoDeviceBase device)
         {
-            if(await ConnectSerialDeviceAsync((device as NanoDevice<NanoSerialDevice>).Device.DeviceInformation as SerialDeviceInformation, device.DeviceBase as SerialDevice))
+            if (await ConnectSerialDeviceAsync((device as NanoDevice<NanoSerialDevice>).Device.DeviceInformation as SerialDeviceInformation, device.DeviceBase as SerialDevice))
             {
                 if (device.DeviceBase == null)
                 {
@@ -609,7 +609,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
                 // kill debug engine
                 device.DebugEngine.Stop();
-                device.DebugEngine = null; 
+                device.DebugEngine = null;
 
                 EventHandlerForSerialDevice.Current.CloseDevice();
             }
@@ -647,7 +647,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
         public async Task<uint> SendBufferAsync(byte[] buffer, TimeSpan waiTimeout, CancellationToken cancellationToken)
         {
             // device must be connected
-            if (EventHandlerForSerialDevice.Current.IsDeviceConnected)
+            if (EventHandlerForSerialDevice.Current.IsDeviceConnected && !cancellationToken.IsCancellationRequested)
             {
                 DataWriter outputStreamWriter = new DataWriter(EventHandlerForSerialDevice.Current.Device.OutputStream);
 
@@ -687,7 +687,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
         public async Task<byte[]> ReadBufferAsync(uint bytesToRead, TimeSpan waiTimeout, CancellationToken cancellationToken)
         {
             // device must be connected
-            if (EventHandlerForSerialDevice.Current.IsDeviceConnected)
+            if (EventHandlerForSerialDevice.Current.IsDeviceConnected && !cancellationToken.IsCancellationRequested)
             {
                 DataReader inputStreamReader = new DataReader(EventHandlerForSerialDevice.Current.Device.InputStream);
 

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Controller.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Controller.cs
@@ -40,7 +40,14 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
         public async Task<bool> SendAsync(MessageRaw raw, CancellationToken cancellationToken)
         {
-             _sendSemaphore.WaitOne();
+            _sendSemaphore.WaitOne();
+
+            // check for cancellation request
+            if (cancellationToken.IsCancellationRequested)
+            {
+                // cancellation requested
+                return false;
+            }
 
             try
             {
@@ -116,9 +123,9 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             throw new NotImplementedException();
         }
 
-        private Task<uint> SendRawBufferAsync(byte[] buffer, TimeSpan waiTimeout, CancellationToken cancellationToken)
+        private async Task<uint> SendRawBufferAsync(byte[] buffer, TimeSpan waiTimeout, CancellationToken cancellationToken)
         {
-            return App.SendBufferAsync(buffer, waiTimeout, cancellationToken);
+            return await App.SendBufferAsync(buffer, waiTimeout, cancellationToken);
         }
 
         internal async Task<int> ReadBufferAsync(byte[] buffer, int offset, int bytesToRead, TimeSpan waitTimeout, CancellationToken cancellationToken)

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/WireProtocolRequest.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/WireProtocolRequest.cs
@@ -16,7 +16,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         private CommandEventHandler _callback;
 
         public CancellationToken CancellationToken { get; }
-        public TaskCompletionSource<object> TaskCompletionSource { get; }
+        public TaskCompletionSource<IncomingMessage> TaskCompletionSource { get; }
 
         public DateTimeOffset Expires { get; }
         public OutgoingMessage OutgoingMessage { get; }
@@ -30,10 +30,10 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             Expires = DateTime.Now.AddMilliseconds(millisecondsTimeout);
 
             // https://blogs.msdn.microsoft.com/pfxteam/2009/06/02/the-nature-of-taskcompletionsourcetresult/
-            TaskCompletionSource = new TaskCompletionSource<object>();
+            TaskCompletionSource = new TaskCompletionSource<IncomingMessage>();
             CancellationToken = cancellationToken;
         }
-        
+
         internal async Task<bool> PerformRequestAsync(IController controller)
         {
             Debug.WriteLine($"Performing request");


### PR DESCRIPTION
## Description
- Rework async and sync requests
- TaskCompletionSource now uses fixed type instead of object
- Extra check for cancelation request on serial send and receive methods

## Motivation and Context
- Work on improving general stability and solve VS hanging

## How Has This Been Tested?<!-- (if applicable) -->
- WPF test app and VS experimental instance

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
