### PR TITLE
Work on stability

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -13,6 +13,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
@@ -270,24 +271,37 @@ namespace Serial_Test_App_WPF
 
             List<byte[]> assemblies = new List<byte[]>(4);
             // test data
-// mscorlib v(36500 bytes)
-// Windows.Storage.Streams v(6180 bytes)
-// Windows.Devices.SerialCommunication v(3172 bytes)
-// SerialCommunication v1.0.6578.34099(1180 bytes)
-// assemblies to device...total size in bytes is 47032.
+            // mscorlib v(36500 bytes)
+            // Windows.Storage.Streams v(6180 bytes)
+            // Windows.Devices.SerialCommunication v(3172 bytes)
+            // SerialCommunication v1.0.6578.34099(1180 bytes)
+            // assemblies to device...total size in bytes is 47032.
 
-              assemblies.Add(new byte[36500]);
+            var p1Size = 36500;
+            var p2Size = 6180;
+            var p3Size = 3172;
+            var p4Size = 1180;
+
+
+            assemblies.Add(new byte[p1Size]);
             assemblies[0][0] = 0x5;
             assemblies[0][1] = 0x5;
-            assemblies.Add(new byte[6180]);
+            assemblies.Add(new byte[p2Size]);
             assemblies[1][0] = 0x6;
             assemblies[1][1] = 0x6;
-            assemblies.Add(new byte[3172]);
+            assemblies.Add(new byte[p3Size]);
             assemblies[2][0] = 0x7;
             assemblies[2][1] = 0x7;
-            assemblies.Add(new byte[1180]);
+            assemblies.Add(new byte[p4Size]);
             assemblies[3][0] = 0x8;
             assemblies[3][1] = 0x8;
+
+            var totalSize = p1Size + p2Size + p3Size + p4Size;
+
+            var largePackets = totalSize / (1024 - 8);
+
+            Debug.WriteLine($">>> Sending : {totalSize} bytes.<<<<");
+            Debug.WriteLine($">>> This is {largePackets} 1k packets plus  bytes.<<<<");
 
             try
             {
@@ -310,6 +324,13 @@ namespace Serial_Test_App_WPF
                     var result = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.DeploymentExecute(assemblies, false);
 
                     Debug.WriteLine($">>> Deployment result: {result} <<<<");
+
+
+                    (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.RebootDevice(RebootOption.RebootClrOnly);
+
+                    Task.Delay(1000).Wait();
+
+                    (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].GetDeviceInfo(true);
 
                 }));
             }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/EventHandlerForSerialDevice.cs
@@ -4,7 +4,9 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Windows.Devices.Enumeration;
 using Windows.Devices.SerialCommunication;
 using Windows.Foundation;
@@ -262,8 +264,13 @@ namespace nanoFramework.Tools.Debugger.Serial
 
                 Debug.WriteLine($"Closing device {_deviceInformation?.Id}");
 
+                var tasks = new List<Task>();
+                tasks.Add(Task.Factory.StartNew(() => _device.Dispose()));
+
                 // This closes the handle to the device
-                _device.Dispose();
+                Task.WaitAll(tasks.ToArray(), 2000);
+
+                _device = null;
             }
         }
 

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Controller.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Controller.cs
@@ -130,6 +130,13 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
         internal async Task<int> ReadBufferAsync(byte[] buffer, int offset, int bytesToRead, TimeSpan waitTimeout, CancellationToken cancellationToken)
         {
+            // check for cancellation request
+            if (cancellationToken.IsCancellationRequested)
+            {
+                // cancellation requested
+                return 0;
+            }
+
             int bytesToReadRequested = bytesToRead;
 
             try

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -1197,17 +1197,7 @@ namespace nanoFramework.Tools.Debugger
                 Commands.Monitor_WriteMemory cmd = new Commands.Monitor_WriteMemory();
 
                 // get packet length, either the maximum allowed size or whatever is still available to TX
-                // on the maximum packet size: 8 bytes are being subtracted to account for the CRC32 value
-                // the above seems to be paramount because the WinRT API seems to have issues with USB packets smaller than 64 bytes
                 int packetLength = Math.Min(1024, count);
-
-                //// sanity check for length because TXing a packet with less than 64 bytes seems to be causing issues
-                //// on the maximum packet size: 8 bytes are being subtracted to account for the CRC32 value
-                //if ((count - packetLength) < 56 && count > 56)
-                //{
-                //    // need to adjust this length so that 64 bytes are left for the last packet
-                //    packetLength = (count - 56);
-                //}
 
                 cmd.PrepareForSend(address, buf, position, packetLength);
 

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -1199,14 +1199,15 @@ namespace nanoFramework.Tools.Debugger
                 // get packet length, either the maximum allowed size or whatever is still available to TX
                 // on the maximum packet size: 8 bytes are being subtracted to account for the CRC32 value
                 // the above seems to be paramount because the WinRT API seems to have issues with USB packets smaller than 64 bytes
-                int packetLength = Math.Min(1024 - 8, count);
+                int packetLength = Math.Min(1024, count);
 
-                // sanity check for length because TXing a packet with less than 64 bytes seems to be causing issues
-                if ((count - packetLength) < 64 && count > 64)
-                {
-                    // need to adjust this length so that 64 bytes are left for the last packet
-                    packetLength = (count - 64);
-                }
+                //// sanity check for length because TXing a packet with less than 64 bytes seems to be causing issues
+                //// on the maximum packet size: 8 bytes are being subtracted to account for the CRC32 value
+                //if ((count - packetLength) < 56 && count > 56)
+                //{
+                //    // need to adjust this length so that 64 bytes are left for the last packet
+                //    packetLength = (count - 56);
+                //}
 
                 cmd.PrepareForSend(address, buf, position, packetLength);
 


### PR DESCRIPTION
## Description
- Remove hack in writememory
- General improvements in several methods
- Update code in test app
- Improved dispose code

## Motivation and Context
- This was a hack to overcome an issue with USB packets smaller than 64 bytes at the end of the batch (not required anymore) it has to be handled at the native end. See nanoframework/nf-interpreter#596

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
