### PR TITLE
Work on config block get and update

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -746,7 +746,7 @@ namespace Serial_Test_App_WPF
                      newDeviceNetworkConfiguration.IPv4DNS1Address = IPAddress.Parse("192.168.1.254");
 
                      // write device configuration to device
-                     var returnValue = device.DebugEngine.WriteDeviceConfiguration(newDeviceNetworkConfiguration);
+                     var returnValue = device.DebugEngine.UpdateDeviceConfiguration(newDeviceNetworkConfiguration);
 
                      Debug.WriteLine("");
                      Debug.WriteLine("");

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/DeviceConfigurationOption.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/DeviceConfigurationOption.cs
@@ -1,0 +1,25 @@
+﻿//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Tools.Debugger
+{
+    public partial class DeviceConfiguration
+    {
+        /// <summary>
+        ///  Device configuration option
+        /// </summary>
+        public enum DeviceConfigurationOption : byte
+        {
+            ////////////////////////////////////////////////////////////////////////////////////
+            // NEED TO KEEP THESE IN SYNC WITH native 'AddressMode' enum in nanoHAL_Network.h //
+            ////////////////////////////////////////////////////////////////////////////////////
+
+            /// <summary>
+            /// Network configuration
+            /// </summary>
+            Network = 1,
+        }
+    }
+}

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -28,6 +28,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         public const uint c_Monitor_FlashSectorMap = 0x0000000C;
         public const uint c_Monitor_OemInfo = 0x0000000E;
         public const uint c_Monitor_QueryConfiguration = 0x0000000F;
+        public const uint c_Monitor_UpdateConfiguration = 0x00000010;
 
         public class Monitor_Message : IConverter
         {
@@ -260,8 +261,6 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
         public class Monitor_QueryConfiguration
         {
-            public const uint c_ConfigurationNetwork = 1;
-
             public uint Configuration;
 
             public class Reply : IConverter
@@ -301,6 +300,26 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 }
             }
 
+        }
+
+        public class Monitor_UpdateConfiguration
+        {
+            public uint Configuration;
+            public uint Length = 0;
+            public byte[] Data = null;
+
+            public class Reply
+            {
+                public uint ErrorCode;
+            };
+
+            public void PrepareForSend(byte[] data, int length)
+            {
+                Length = (uint)length;
+                Data = new byte[length];
+
+                Array.Copy(data, 0, Data, 0, length);
+            }
         }
 
         public const uint c_Debugging_Execution_BasePtr = 0x00020000; // Returns the pointer for the ExecutionEngine object.
@@ -1551,6 +1570,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                     case c_Monitor_DeploymentMap: return new Monitor_DeploymentMap.Reply();
                     case c_Monitor_FlashSectorMap: return new Monitor_FlashSectorMap.Reply();
                     case c_Monitor_QueryConfiguration: return new Monitor_QueryConfiguration.Reply();
+                    case c_Monitor_UpdateConfiguration: return new Monitor_UpdateConfiguration.Reply();
 
                     case c_Debugging_Execution_BasePtr: return new Debugging_Execution_BasePtr.Reply();
                     case c_Debugging_Execution_ChangeConditions: return new DebuggingExecutionChangeConditions.Reply();

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/nanoFramework.Tools.DebugLibrary.Net.projitems
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/nanoFramework.Tools.DebugLibrary.Net.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CLRCapabilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CRC32.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DebuggerEventSource.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DeviceConfiguration\DeviceConfigurationOption.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeviceConfiguration\AddressMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeviceConfiguration\DeviceConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeviceConfiguration\DeviceConfigurationBase.cs" />


### PR DESCRIPTION
## Description
- Add new command: Monitor_UpdateConfiguration
- Configuration Option for configuration get/update commands is now an enum DeviceConfigurationOption
- Rename WriteDeviceConfigurationAsBlock to UpdateDeviceConfigurationAsBlock
- Rework UpdateDeviceConfigurationAsBlock to use it's own command implementation instead of direct memory write. This is to accomodate targets that do not store their configuration directly in flash memory
- Update test app with the above

## Motivation and Context


## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>