### PR TITLE
Add suport for ConfigBlockRequiresErase flag in Capabilities

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Shared/CLRCapabilities.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/CLRCapabilities.cs
@@ -25,6 +25,11 @@ namespace nanoFramework.Tools.Debugger
             Profiling_Allocations = 0x00000080,
             Profiling_Calls = 0x00000100,
             ThreadCreateEx = 0x00000400,
+
+            /// <summary>
+            /// This flag indicates that the device requires em erase command before updating the configuration block.
+            /// </summary>
+            ConfigBlockRequiresErase = 0x00000800,
         }
 
         public struct SoftwareVersionProperties
@@ -286,6 +291,15 @@ namespace nanoFramework.Tools.Debugger
             {
                 Debug.Assert(!m_fUnknown);
                 return (m_capabilities & Capability.Profiling_Calls) != 0;
+            }
+        }
+
+        public bool ConfigBlockRequiresErase
+        {
+            get
+            {
+                Debug.Assert(!m_fUnknown);
+                return (m_capabilities & Capability.ConfigBlockRequiresErase) != 0;
             }
         }
 


### PR DESCRIPTION
## Description
- Add this new flag to the Capabilites struct
- Update UpdateDeviceConfigurationAsBlock accordingly 

## Motivation and Context
This required to accommodate targets with different flavours of configuration block storage/management. Looking into this flag the engine knows if a flash erase is required before uploading the configuration block.

## How Has This Been Tested?<!-- (if applicable) -->
- Requires nanoframework/nf-interpreter#648

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>