### PR TITLE
Fix problem on SerialPort  ReadBufferAsync

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
@@ -706,7 +706,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
                     if (bytesRead > 0)
                     {
-                        byte[] readBuffer = new byte[bytesToRead];
+                        byte[] readBuffer = new byte[bytesRead];
                         inputStreamReader?.ReadBytes(readBuffer);
 
                         return readBuffer;


### PR DESCRIPTION
## Description
This fixes a problem which caused the ReadBufferAsync etc to get in a tight loop. Trying to read data but finding the device handle is invalid which creates an exception. The calling code will try to connect again but picks up invalid handle as it thinks it still connected then tries to do a read again.

The original problem is that LoadAsync(32) initially only returns 19 bytes when the ESP32 is rebooting after a deploy.

Because it created a buffer of 32 bytes the ReadBytes tries to read 32 bytes from stream but there are only 19 available so we get an exception, data out of range.

This never ending loop also causes the Visual Studio to not close properly and processes are left in the background using lots of CPU time.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy<adriansoundy@gmail.com>
