### PR TITLE
Fix issues with wireless config save/load

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -739,16 +739,29 @@ namespace Serial_Test_App_WPF
                      //deviceConfig.NetworkConfiguraton.MacAddress = new byte[] { 0, 0x80, 0xe1, 0x01, 0x35, 0x56 };
                      //deviceConfig.NetworkConfiguraton.StartupAddressMode = DeviceConfiguration.AddressMode.DHCP;
 
-                     // set new network configuration on the specific class
-                     DeviceConfiguration.NetworkConfigurationProperties newDeviceNetworkConfiguration = new DeviceConfiguration.NetworkConfigurationProperties();
-                     newDeviceNetworkConfiguration.MacAddress = new byte[] { 0, 0x80, 0xe1, 0x01, 0x35, 0x56 };
-                     newDeviceNetworkConfiguration.InterfaceType = nanoFramework.Tools.Debugger.NetworkInterfaceType.Ethernet;
-                     newDeviceNetworkConfiguration.StartupAddressMode = AddressMode.DHCP;
+                     // update new network configuration
+                     DeviceConfiguration.NetworkConfigurationProperties newDeviceNetworkConfiguration = new DeviceConfiguration.NetworkConfigurationProperties
+                     {
+                         MacAddress = new byte[] { 0, 0x80, 0xe1, 0x01, 0x35, 0x56 },
+                         InterfaceType = nanoFramework.Tools.Debugger.NetworkInterfaceType.Ethernet,
+                         StartupAddressMode = AddressMode.DHCP,
 
-                     newDeviceNetworkConfiguration.IPv4DNSAddress1 = IPAddress.Parse("192.168.1.254");
+                         IPv4DNSAddress1 = IPAddress.Parse("192.168.1.254"),
+                     };
 
                      // write device configuration to device
                      var returnValue = device.DebugEngine.UpdateDeviceConfiguration(newDeviceNetworkConfiguration, 0);
+
+                     // add new wireless 802.11 configuration
+                     DeviceConfiguration.Wireless80211ConfigurationProperties newWireless80211Configuration = new DeviceConfiguration.Wireless80211ConfigurationProperties()
+                     {
+                         Id = 44,
+                         Ssid = "Nice_Ssid",
+                         Password = "1234",
+                     };
+
+                     // write wireless configuration to device
+                     returnValue = device.DebugEngine.UpdateDeviceConfiguration(newWireless80211Configuration, 0);
 
                      Debug.WriteLine("");
                      Debug.WriteLine("");

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/DeviceConfiguration.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/DeviceConfiguration.cs
@@ -210,8 +210,8 @@ namespace nanoFramework.Tools.Debugger
                 Authentication = (AuthenticationType)config.Authentication;
                 Encryption = (EncryptionType)config.Encryption;
                 Radio = (RadioType)config.Radio;
-                Ssid = config.Ssid;
-                Password = config.Password;
+                Ssid = Encoding.UTF8.GetString(config.Ssid).Trim('\0');
+                Password = Encoding.UTF8.GetString(config.Password).Trim('\0');
 
                 // reset unknown flag
                 IsUnknown = false;
@@ -225,13 +225,15 @@ namespace nanoFramework.Tools.Debugger
                     Marker = Encoding.UTF8.GetBytes(MarkerConfigurationWireless80211_v1),
 
                     Id = value.Id,
-
                     Authentication = (byte)value.Authentication,
                     Encryption = (byte)value.Encryption,
                     Radio = (byte)value.Radio,
-                    Ssid = value.Ssid,
-                    Password = value.Password,
-            };
+                };
+
+                // the following ones are strings so they need to be copied over to the array 
+                // this is required to when serializing the class the struct size matches the one in the native end
+                Array.Copy(Encoding.UTF8.GetBytes(value.Ssid), 0, networkWirelessConfig.Ssid, 0, value.Ssid.Length);
+                Array.Copy(Encoding.UTF8.GetBytes(value.Password), 0, networkWirelessConfig.Password, 0, value.Password.Length);
 
                 return networkWirelessConfig;
             }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/NetworkConfigurationBase.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/NetworkConfigurationBase.cs
@@ -83,5 +83,11 @@ namespace nanoFramework.Tools.Debugger
         /// Address mode (static, DHCP or auto IP)
         /// </summary>
         public byte StartupAddressMode;
+
+        public NetworkConfigurationBase()
+        {
+            // need to init this here to match the expected size on the struct to be sent to the device
+            Marker = new byte[4];
+        }
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/Wireless80211Base.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/Wireless80211Base.cs
@@ -39,12 +39,22 @@ namespace nanoFramework.Tools.Debugger
 
         /// <summary>
         /// Network SSID
+        /// 32 bytes length.
         /// </summary>
-        public string Ssid;
+        public byte[] Ssid;
 
         /// <summary>
         /// Network password 
+        /// 64 bytes length.
         /// </summary>
-        public string Password;
+        public byte[] Password;
+
+        public Wireless80211ConfigurationBase()
+        {
+            // need to init these here to match the expected size on the struct to be sent to the device
+            Marker = new byte[4];
+            Ssid = new byte[32];
+            Password = new byte[64];
+        }
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -312,7 +312,9 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                     Authentication = (byte)AuthenticationType.None ;
                     Encryption = (byte)EncryptionType.None;
                     Radio = (byte)RadioType.None;
-            }
+                    Ssid = new byte[32];
+                    Password = new byte[64];
+                }
 
                 public void PrepareForDeserialize(int size, byte[] data, Converter converter)
                 {
@@ -321,6 +323,8 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                     Authentication = (byte)AuthenticationType.None;
                     Encryption = (byte)EncryptionType.None;
                     Radio = (byte)RadioType.None;
+                    Ssid = new byte[32];
+                    Password = new byte[64];
                 }
             }
         }


### PR DESCRIPTION
## Description
- The string fields weren't being properly handled
- Add constructors to config base classes to ensure that the byte arrays size match
- Minor improvements in WPF test app

## Motivation and Context
- Fixes issue with storing/getting wireless config block to/from device

## How Has This Been Tested?<!-- (if applicable) -->
- WPF test app

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>