### PR TITLE
Work on WPF test app

### DIFF
--- a/source/USB Test App WPF/Serial Test App WPF.csproj
+++ b/source/USB Test App WPF/Serial Test App WPF.csproj
@@ -139,7 +139,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\nanoFramework.Tools.DebugLibrary.Net\nanoFramework.Tools.DebugLibrary.Net.csproj">
-      <Project>{101D57AD-D22F-4905-A992-DE15E723F164}</Project>
+      <Project>{101d57ad-d22f-4905-a992-de15e723f164}</Project>
       <Name>nanoFramework.Tools.DebugLibrary.Net</Name>
     </ProjectReference>
   </ItemGroup>

--- a/source/USB Test App WPF/packages.config
+++ b/source/USB Test App WPF/packages.config
@@ -5,7 +5,6 @@
   <package id="MvvmLight" version="5.3.0.0" targetFramework="net462" />
   <package id="MvvmLightLibs" version="5.3.0.0" targetFramework="net462" />
   <package id="nanoFramework.CoreLibrary" version="1.0.0-preview042" targetFramework="net46" />
-  <package id="nanoFramework.Tools.Debugger.Net" version="0.5.0-alpha108" targetFramework="net46" />
   <package id="PropertyChanged.Fody" version="2.2.4.0" targetFramework="net46" developmentDependency="true" />
   <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net46" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />


### PR DESCRIPTION
- Project now references debugger project instead of Nuget

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
