### PR TITLE
Move command to list native interop assemblies to QueryCLRCapabilities

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml
+++ b/source/USB Test App WPF/MainWindow.xaml
@@ -34,7 +34,6 @@
         <Button Content="Device Capabilites" HorizontalAlignment="Left" Margin="39,195,0,0" VerticalAlignment="Top" Width="110" Click="DeviceCapabilitesButton_Click" />
         <Button Content="Flash Map" HorizontalAlignment="Left" Margin="39,275,0,0" VerticalAlignment="Top" Width="110" Click="FlashMapButton_Click" />
         <Button Content="Resolve Assemblies" HorizontalAlignment="Left" Margin="39,235,0,0" VerticalAlignment="Top" Width="110" Click="ResolveAssembliesButton_Click" />
-        <Button Content="Native Assemblies" HorizontalAlignment="Left" Margin="39,313,0,0" VerticalAlignment="Top" Width="110" Click="ListNativeAssembliesButton_Click" />
 
         <Button Content="Pause Execution" HorizontalAlignment="Left" Margin="250,235,0,0" VerticalAlignment="Top" Width="98" Click="PauseExecutionButton_Click" />
         <Button Content="Resume Execution" HorizontalAlignment="Left" Margin="250,275,0,0" VerticalAlignment="Top" Width="98" Click="ResumeExecutionButton_Click" />

--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -191,36 +191,6 @@ namespace Serial_Test_App_WPF
             (sender as Button).IsEnabled = true;
         }
 
-        private async void ListNativeAssembliesButton_Click(object sender, RoutedEventArgs e)
-        {
-            // disable button
-            (sender as Button).IsEnabled = false;
-
-            await Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() =>
-             {
-
-                 try
-                 {
-                     var result = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.GetInteropNativeAssemblies();
-
-                     Debug.WriteLine("Native Assembly list:");
-                     
-                     foreach (Commands.Debugging_TypeSys_InteropNativeAssemblies.NativeAssemblyDetails assembly in result)
-                     {
-                         Debug.WriteLine($" {assembly.Name} :: checksum 0x{assembly.CheckSum.ToString("X8")}");
-                     }
-                 }
-                 catch
-                 {
-
-                 }
-
-             }));
-
-            // enable button
-            (sender as Button).IsEnabled = true;
-        }
-
         private async void DeviceCapabilitesButton_Click(object sender, RoutedEventArgs e)
         {
             // disable button

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/CLRCapabilities.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/CLRCapabilities.cs
@@ -5,6 +5,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace nanoFramework.Tools.Debugger
@@ -137,17 +138,32 @@ namespace nanoFramework.Tools.Debugger
             }
         }
 
+        public struct NativeAssemblyProperties
+        {
+            public uint Checksum;
+            public Version Version; // TODO add 'version info' in a future version
+            public string Name;
+
+            public NativeAssemblyProperties(string name, uint checksum, Version version)
+            {
+                Checksum = checksum;
+                Name = name;
+                Version = version;
+            }
+        }
+
         private Capability m_capabilities;
         private SoftwareVersionProperties m_swVersion;
         private HalSystemInfoProperties m_halSystemInfo;
         private ClrInfoProperties m_clrInfo;
         private TargetInfoProperties m_targetReleaseInfo;
+        private List<NativeAssemblyProperties> m_nativeAssembliesInfo;
 
         private bool m_fUnknown;
 
         public CLRCapabilities()
             : this(Capability.None, new SoftwareVersionProperties(),
-                new HalSystemInfoProperties(), new ClrInfoProperties(), new TargetInfoProperties())
+                new HalSystemInfoProperties(), new ClrInfoProperties(), new TargetInfoProperties(), new List<NativeAssemblyProperties>())
         {
         }
 
@@ -156,7 +172,8 @@ namespace nanoFramework.Tools.Debugger
             SoftwareVersionProperties ver,
             HalSystemInfoProperties halSystemInfo,
             ClrInfoProperties clrInfo,
-            TargetInfoProperties solutionReleaseInfo
+            TargetInfoProperties solutionReleaseInfo,
+            List<NativeAssemblyProperties> nativeAssembliesInfo
             )
         {
             m_fUnknown = (capability == Capability.None);
@@ -166,6 +183,7 @@ namespace nanoFramework.Tools.Debugger
             m_halSystemInfo = halSystemInfo;
             m_clrInfo = clrInfo;
             m_targetReleaseInfo = solutionReleaseInfo;
+            m_nativeAssembliesInfo = nativeAssembliesInfo;
         }
 
         public HalSystemInfoProperties HalSystemInfo
@@ -201,6 +219,14 @@ namespace nanoFramework.Tools.Debugger
             {
                 Debug.Assert(!m_fUnknown);
                 return m_swVersion;
+            }
+        }
+        public List<NativeAssemblyProperties> NativeAssemblies
+        {
+            get
+            {
+                Debug.Assert(!m_fUnknown);
+                return m_nativeAssembliesInfo;
             }
         }
 

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/NanoFrameworkDeviceInfo.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/NanoFrameworkDeviceInfo.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using System.Threading;
+using System.Linq;
 
 namespace nanoFramework.Tools.Debugger
 {
@@ -39,6 +40,8 @@ namespace nanoFramework.Tools.Debugger
                 {
 
                     Valid = true;
+
+                    NativeAssemblies = Dbg.Capabilities.NativeAssemblies;
 
                     return true;
                 }
@@ -116,7 +119,7 @@ namespace nanoFramework.Tools.Debugger
             // default to failure
             return false;
         }
-
+        
         private Engine Dbg { get { return m_self.DebugEngine; } }
 
         public bool Valid { get; internal set; }
@@ -191,6 +194,8 @@ namespace nanoFramework.Tools.Debugger
             get { return m_AssemblyInfos.ToArray(); }
         }
 
+        public List<CLRCapabilities.NativeAssemblyProperties> NativeAssemblies { get; private set; } = new List<CLRCapabilities.NativeAssemblyProperties> ();
+
         public string ImageBuildDate => Dbg.Capabilities.SoftwareVersion.BuildDate;
 
         public string ImageCompilerInfo => Dbg.Capabilities.SoftwareVersion.CompilerInfo;
@@ -223,6 +228,12 @@ namespace nanoFramework.Tools.Debugger
                     foreach (IAssemblyInfo ai in Assemblies)
                     {
                         output.AppendLine(String.Format("  {0}, {1}", ai.Name, ai.Version));
+                    }
+
+                    output.AppendLine("Native Assemblies:");
+                    foreach (CLRCapabilities.NativeAssemblyProperties assembly in NativeAssemblies)
+                    {
+                        output.AppendLine($"  {assembly.Name} v{assembly.Version}, checksum 0x{assembly.Checksum.ToString("X8")}");
                     }
 
                     return output.ToString();


### PR DESCRIPTION
# Description
- Update QueryCLRCapabilities to hold a list with the native assemblies details
- Update NanoFrameworkDeviceInfo.ToString() to have a nicelly formated list of the native assemblies
- Remove GetInteropNativeAssemblies from engine
- Update WPF test app accordingly

## Motivation and Context
- Working towards nanoFramework/Home#329

## How Has This Been Tested?<!-- (if applicable) -->
- WPF test app

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
