### PR TITLE
Major rework on SerialDevice and Engine

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -41,6 +41,11 @@ namespace Serial_Test_App_WPF
             {
                 var device = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex];
 
+                if(device.DebugEngine == null)
+                {
+                    device.CreateDebugEngine();
+                }
+
                 bool connectResult = await device.DebugEngine.ConnectAsync(5000, true);
 
                 //(DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.Start();
@@ -108,6 +113,8 @@ namespace Serial_Test_App_WPF
                     (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.Stop();
                     (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.Dispose();
                     (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine = null;
+
+                    ((DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex] as NanoDevice<NanoSerialDevice>).Disconnect();
                 }
                 catch
                 {
@@ -506,6 +513,10 @@ namespace Serial_Test_App_WPF
                     (sender as Button).IsEnabled = true;
 
                     (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.RebootDevice(nanoFramework.Tools.Debugger.RebootOptions.NormalReboot);
+
+                    (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.Stop();
+                    (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.Dispose();
+                    (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine = null;
 
                     Debug.WriteLine("");
                     Debug.WriteLine("");

--- a/source/nanoFramework.Tools.DebugLibrary.Net/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/PortSerial/EventHandlerForSerialDevice.cs
@@ -101,18 +101,11 @@ namespace nanoFramework.Tools.Debugger.Serial
         /// <param name="deviceSelector">The AQS used to find this device</param>
         /// <returns>True if the device was successfully opened, false if the device could not be opened for well known reasons.
         /// An exception may be thrown if the device could not be opened for extraordinary reasons.</returns>
-        public async Task<bool> OpenDeviceAsync(DeviceInformation deviceInfo, string deviceSelector, SerialDevice existingDevice)
+        public async Task<bool> OpenDeviceAsync(DeviceInformation deviceInfo, string deviceSelector)
         {
             bool successfullyOpenedDevice = false;
 
-            if (existingDevice == null)
-            {
-                _device = await SerialDevice.FromIdAsync(deviceInfo.Id);
-            }
-            else
-            {
-                _device = existingDevice;
-            }
+            _device = await SerialDevice.FromIdAsync(deviceInfo.Id);
 
             try
             {
@@ -129,7 +122,7 @@ namespace nanoFramework.Tools.Debugger.Serial
                     // adjust settings for serial port
                     _device.BaudRate = 115200;
                     _device.DataBits = 8;
-                    
+
                     /////////////////////////////////////////////////////////////
                     // need to FORCE the parity setting to _NONE_ because        
                     // the default on the current ST Link is different causing 

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDevice.cs
@@ -93,6 +93,8 @@ namespace nanoFramework.Tools.Debugger
         public void Disconnect()
         {
             Parent.DisconnectDevice(this as NanoDeviceBase);
+
+            DeviceBase = null;
         }
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
@@ -20,26 +20,20 @@ namespace nanoFramework.Tools.Debugger
 {
     public abstract class NanoDeviceBase
     {
-        private Engine _debugEngine;
 
 
         /// <summary>
         /// nanoFramework debug engine.
         /// </summary>
         /// 
-        public Engine DebugEngine
+        public Engine DebugEngine { get; set; }
+
+        /// <summary>
+        /// Create a new debug engine for this nanoDevice.
+        /// </summary>
+        public void CreateDebugEngine()
         {
-            get
-            { 
-                if (_debugEngine == null)
-                {
-                    _debugEngine = new Engine(this);
-                }
-
-                return _debugEngine;
-            }
-
-            set => _debugEngine = value;
+            DebugEngine = new Engine(this);
         }
 
         /// <summary>
@@ -119,11 +113,16 @@ namespace nanoFramework.Tools.Debugger
         }
 
         /// <summary>
-        /// Attempts to communicate with the connected .Net Micro Framework device
+        /// Attempts to communicate with the connected nanoFramework device
         /// </summary>
         /// <returns></returns>
         public PingConnectionType Ping()
         {
+            if(DebugEngine == null)
+            {
+                throw new DeviceNotConnectedException();
+            }
+
             var reply = DebugEngine.GetConnectionSource();
 
             if (reply != null)

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/EventHandlerForSerialDevice.cs
@@ -47,7 +47,6 @@ namespace nanoFramework.Tools.Debugger.Serial
         private bool _watcherStarted;
 
         private bool _isBackgroundTask;
-        private bool _isEnabledAutoReconnect;
 
         // A pointer back to the calling app.  This is needed to reach methods and events there 
 #if WINDOWS_UWP
@@ -191,21 +190,6 @@ namespace nanoFramework.Tools.Debugger.Serial
             }
         }
 
-        /// <summary>
-        /// True if EventHandlerForSerialEclo will attempt to reconnect to the device once it is plugged into the computer again
-        /// </summary>
-        public bool IsEnabledAutoReconnect
-        {
-            get
-            {
-                return _isEnabledAutoReconnect;
-            }
-            set
-            {
-                _isEnabledAutoReconnect = value;
-            }
-        }
-
         private void Device_ErrorReceived(SerialDevice sender, ErrorReceivedEventArgs args)
         {
             //throw new NotImplementedException();
@@ -225,11 +209,7 @@ namespace nanoFramework.Tools.Debugger.Serial
             _deviceInformation = null;
             _deviceSelector = null;
 
-            _isEnabledAutoReconnect = true;
-
             Debug.WriteLine($"##################");
-            Current._device?.Dispose();
-            Current._device = null;
         }
 
         /// <summary>
@@ -241,8 +221,7 @@ namespace nanoFramework.Tools.Debugger.Serial
         {
             _watcherStarted = false;
             _watcherSuspended = false;
-            _isEnabledAutoReconnect = true;
-            this._isBackgroundTask = isBackgroundTask;
+            _isBackgroundTask = isBackgroundTask;
         }
 
         /// <summary>
@@ -270,17 +249,17 @@ namespace nanoFramework.Tools.Debugger.Serial
                 {
                     // This closes the handle to the device
                     _device.Dispose();
+                    _device = null;
                 });
 
-                // need to wrap this in try-catch to catch possible AggregateExceptions
+                //need to wrap this in try-catch to catch possible AggregateExceptions
                 try
                 {
                     Task.WaitAll(new Task[] { closeTask }, TimeSpan.FromMilliseconds(1000));
                 }
                 catch { }
 
-                _device = null;
-            }
+                }
         }
 
         /// <summary>
@@ -376,7 +355,7 @@ namespace nanoFramework.Tools.Debugger.Serial
         /// <param name="deviceInfo"></param>
         private void OnDeviceAdded(DeviceWatcher sender, DeviceInformation deviceInfo)
         {
-            if ((_deviceInformation != null) && (deviceInfo.Id == _deviceInformation.Id) && !IsDeviceConnected && _isEnabledAutoReconnect)
+            if ((_deviceInformation != null) && (deviceInfo.Id == _deviceInformation.Id) && !IsDeviceConnected)
             {
             }
         }

--- a/source/nanoFramework.Tools.DebugLibrary.UWP/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.UWP/PortSerial/EventHandlerForSerialDevice.cs
@@ -124,20 +124,13 @@ namespace nanoFramework.Tools.Debugger.Serial
         /// <param name="deviceSelector">The AQS used to find this device</param>
         /// <returns>True if the device was successfully opened, false if the device could not be opened for well known reasons.
         /// An exception may be thrown if the device could not be opened for extraordinary reasons.</returns>
-        public async Task<bool> OpenDeviceAsync(DeviceInformation deviceInfo, string deviceSelector, SerialDevice existingDevice)
+        public async Task<bool> OpenDeviceAsync(DeviceInformation deviceInfo, string deviceSelector)
         {
             await Task.Delay(250);
 
             bool successfullyOpenedDevice = false;
 
-            if (existingDevice == null)
-            {
-                _device = await SerialDevice.FromIdAsync(deviceInfo.Id);
-            }
-            else
-            {
-                _device = existingDevice;
-            }
+            _device = await SerialDevice.FromIdAsync(deviceInfo.Id);
 
             try
             {
@@ -153,14 +146,14 @@ namespace nanoFramework.Tools.Debugger.Serial
 
                     // adjust settings for serial port
                     _device.BaudRate = 115200;
-					_device.DataBits = 8;
-                    
-                     /////////////////////////////////////////////////////////////
+                    _device.DataBits = 8;
+
+                    /////////////////////////////////////////////////////////////
                     // need to FORCE the parity setting to _NONE_ because        
                     // the default on the current ST Link is different causing 
                     // the communication to fail
                     /////////////////////////////////////////////////////////////
-                   _device.Parity = SerialParity.None;
+                    _device.Parity = SerialParity.None;
 
                     _device.WriteTimeout = TimeSpan.FromMilliseconds(1000);
                     _device.ReadTimeout = TimeSpan.FromMilliseconds(1000);
@@ -243,7 +236,7 @@ namespace nanoFramework.Tools.Debugger.Serial
             {
                 CloseCurrentlyConnectedDevice();
             }
-            else if ((eventArgs.Status == DeviceAccessStatus.Allowed) && (_deviceInformation != null) && _isEnabledAutoReconnect)
+            else if ((eventArgs.Status == DeviceAccessStatus.Allowed) && (_deviceInformation != null))
             {
             }
         }


### PR DESCRIPTION
## Description
- Partial rewrite on the connect device workflow
- Improvements on the disconnect device worfflow
- SerialPort now has Read and Send cancellation tokens to improve cancelling of pending I/O operations on device disconnect
- Valid nanoDevice checking after complete devices enumeration is now carried as a separate task and not part of handler anymore
- Remove unused flag for autoreconnect on serial device event handler
- DebugEngine propery in NanoDeviceBase doesn't auto-instanciate anymore
- NanoDeviceBase now has a CreateDebugEngine
- Engine doesn't offer a Disconnect method anymore
- Engine doesn's start background processor on constructor anymore becuase the associated nanoDevice might not be connected at that point, instead is started an ConnectAsync if needed
- Engine.RebootDevice doesn't force device disconnection anymore, there are devices that do not require that and even behave oddly if this is forced
- Clean up code and remove several debug output messages
- Update WPF test app


## Motivation and Context
- Improves connect/disconnect/reconnect workflow for USB serial devices

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
