### PR TITLE
Fix to address ESP32 Memory Erase timeout

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -1337,7 +1337,11 @@ namespace nanoFramework.Tools.Debugger
                 timeout = (int)(length / (16 * 1024)) * eraseTimeout16kSector + 2 * extraTimeoutForErase;
             }
 
-            IncomingMessage reply = PerformSyncRequest(Commands.c_Monitor_EraseMemory, 0, cmd);
+            // minimum timeout required for ESP32
+            if (timeout < 10000)
+                timeout = 10000;
+
+            IncomingMessage reply = PerformSyncRequest(Commands.c_Monitor_EraseMemory, 0, cmd, timeout);
 
             if (reply != null)
             {


### PR DESCRIPTION
Forces a minimum Memory Erase timeout.

A workaround to ensure a minimum of 10 seconds is permitted to 
any device performing a Memory Erase before a timeout will occur. 

Addresses timeout issues experienced on ESP32 devices during
debug/deploy.