### PR TITLE
Work on update device config

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -27,6 +27,72 @@ namespace Serial_Test_App_WPF
     /// </summary>
     public partial class MainWindow : Window
     {
+        // Baltimore CyberTrust Root
+        // from https://cacert.omniroot.com/bc2025.crt
+
+        // X509 RSA key PEM format 2048 bytes
+        private const string baltimoreCACertificate =
+@"-----BEGIN CERTIFICATE-----
+MIIDdzCCAl+gAwIBAgIEAgAAuTANBgkqhkiG9w0BAQUFADBaMQswCQYDVQQGEwJJ
+RTESMBAGA1UEChMJQmFsdGltb3JlMRMwEQYDVQQLEwpDeWJlclRydXN0MSIwIAYD
+VQQDExlCYWx0aW1vcmUgQ3liZXJUcnVzdCBSb290MB4XDTAwMDUxMjE4NDYwMFoX
+DTI1MDUxMjIzNTkwMFowWjELMAkGA1UEBhMCSUUxEjAQBgNVBAoTCUJhbHRpbW9y
+ZTETMBEGA1UECxMKQ3liZXJUcnVzdDEiMCAGA1UEAxMZQmFsdGltb3JlIEN5YmVy
+VHJ1c3QgUm9vdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKMEuyKr
+mD1X6CZymrV51Cni4eiVgLGw41uOKymaZN+hXe2wCQVt2yguzmKiYv60iNoS6zjr
+IZ3AQSsBUnuId9Mcj8e6uYi1agnnc+gRQKfRzMpijS3ljwumUNKoUMMo6vWrJYeK
+mpYcqWe4PwzV9/lSEy/CG9VwcPCPwBLKBsua4dnKM3p31vjsufFoREJIE9LAwqSu
+XmD+tqYF/LTdB1kC1FkYmGP1pWPgkAx9XbIGevOF6uvUA65ehD5f/xXtabz5OTZy
+dc93Uk3zyZAsuT3lySNTPx8kmCFcB5kpvcY67Oduhjprl3RjM71oGDHweI12v/ye
+jl0qhqdNkNwnGjkCAwEAAaNFMEMwHQYDVR0OBBYEFOWdWTCCR1jMrPoIVDaGezq1
+BE3wMBIGA1UdEwEB/wQIMAYBAf8CAQMwDgYDVR0PAQH/BAQDAgEGMA0GCSqGSIb3
+DQEBBQUAA4IBAQCFDF2O5G9RaEIFoN27TyclhAO992T9Ldcw46QQF+vaKSm2eT92
+9hkTI7gQCvlYpNRhcL0EYWoSihfVCr3FvDB81ukMJY2GQE/szKN+OMY3EU/t3Wgx
+jkzSswF07r51XgdIGn9w/xZchMB5hbgF/X++ZRGjD8ACtPhSNzkE1akxehi/oCr0
+Epn3o0WC4zxe9Z2etciefC7IpJ5OCBRLbf1wbWsaY71k5h+3zvDyny67G7fyUIhz
+ksLi4xaNmjICq44Y3ekQEe5+NauQrz4wlHrQMz2nZQ/1/I6eYs9HRCwBXbsdtTLS
+R9I4LtD+gdwyah617jzV/OeBHRnDJELqYzmp
+-----END CERTIFICATE-----";
+
+        // Let’s Encrypt Authority X3 (IdenTrust cross-signed)
+        // from https://letsencrypt.org/certificates/
+
+        // X509 RSA key PEM format 2048 bytes
+        private const string letsEncryptCACertificate =
+@"-----BEGIN CERTIFICATE-----
+MIIFjTCCA3WgAwIBAgIRANOxciY0IzLc9AUoUSrsnGowDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTYxMDA2MTU0MzU1
+WhcNMjExMDA2MTU0MzU1WjBKMQswCQYDVQQGEwJVUzEWMBQGA1UEChMNTGV0J3Mg
+RW5jcnlwdDEjMCEGA1UEAxMaTGV0J3MgRW5jcnlwdCBBdXRob3JpdHkgWDMwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCc0wzwWuUuR7dyXTeDs2hjMOrX
+NSYZJeG9vjXxcJIvt7hLQQWrqZ41CFjssSrEaIcLo+N15Obzp2JxunmBYB/XkZqf
+89B4Z3HIaQ6Vkc/+5pnpYDxIzH7KTXcSJJ1HG1rrueweNwAcnKx7pwXqzkrrvUHl
+Npi5y/1tPJZo3yMqQpAMhnRnyH+lmrhSYRQTP2XpgofL2/oOVvaGifOFP5eGr7Dc
+Gu9rDZUWfcQroGWymQQ2dYBrrErzG5BJeC+ilk8qICUpBMZ0wNAxzY8xOJUWuqgz
+uEPxsR/DMH+ieTETPS02+OP88jNquTkxxa/EjQ0dZBYzqvqEKbbUC8DYfcOTAgMB
+AAGjggFnMIIBYzAOBgNVHQ8BAf8EBAMCAYYwEgYDVR0TAQH/BAgwBgEB/wIBADBU
+BgNVHSAETTBLMAgGBmeBDAECATA/BgsrBgEEAYLfEwEBATAwMC4GCCsGAQUFBwIB
+FiJodHRwOi8vY3BzLnJvb3QteDEubGV0c2VuY3J5cHQub3JnMB0GA1UdDgQWBBSo
+SmpjBH3duubRObemRWXv86jsoTAzBgNVHR8ELDAqMCigJqAkhiJodHRwOi8vY3Js
+LnJvb3QteDEubGV0c2VuY3J5cHQub3JnMHIGCCsGAQUFBwEBBGYwZDAwBggrBgEF
+BQcwAYYkaHR0cDovL29jc3Aucm9vdC14MS5sZXRzZW5jcnlwdC5vcmcvMDAGCCsG
+AQUFBzAChiRodHRwOi8vY2VydC5yb290LXgxLmxldHNlbmNyeXB0Lm9yZy8wHwYD
+VR0jBBgwFoAUebRZ5nu25eQBc4AIiMgaWPbpm24wDQYJKoZIhvcNAQELBQADggIB
+ABnPdSA0LTqmRf/Q1eaM2jLonG4bQdEnqOJQ8nCqxOeTRrToEKtwT++36gTSlBGx
+A/5dut82jJQ2jxN8RI8L9QFXrWi4xXnA2EqA10yjHiR6H9cj6MFiOnb5In1eWsRM
+UM2v3e9tNsCAgBukPHAg1lQh07rvFKm/Bz9BCjaxorALINUfZ9DD64j2igLIxle2
+DPxW8dI/F2loHMjXZjqG8RkqZUdoxtID5+90FgsGIfkMpqgRS05f4zPbCEHqCXl1
+eO5HyELTgcVlLXXQDgAWnRzut1hFJeczY1tjQQno6f6s+nMydLN26WuU4s3UYvOu
+OsUxRlJu7TSRHqDC3lSE5XggVkzdaPkuKGQbGpny+01/47hfXXNB7HntWNZ6N2Vw
+p7G6OfY+YQrZwIaQmhrIqJZuigsrbe3W+gdn5ykE9+Ky0VgVUsfxo52mwFYs1JKY
+2PGDuWx8M6DlS6qQkvHaRUo0FMd8TsSlbF0/v965qGFKhSDeQoMpYnwcmQilRh/0
+ayLThlHLN81gSkJjVrPI0Y8xCVPB4twb1PFUd2fPM3sA1tJ83sZ5v8vgFv2yofKR
+PB0t6JzUA81mSqM3kxl5e+IZwhYAyO0OTg3/fs8HqGTNKd9BqoUwSRBzp06JMg5b
+rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
+-----END CERTIFICATE-----";
+
+
         public MainWindow()
         {
             InitializeComponent();
@@ -757,10 +823,6 @@ namespace Serial_Test_App_WPF
                      // get device info
                      var deviceConfig = device.DebugEngine.GetDeviceConfiguration(cts.Token);
 
-                     // change device configuration using the global configuration class
-                     //deviceConfig.NetworkConfiguraton.MacAddress = new byte[] { 0, 0x80, 0xe1, 0x01, 0x35, 0x56 };
-                     //deviceConfig.NetworkConfiguraton.StartupAddressMode = DeviceConfiguration.AddressMode.DHCP;
-
                      // update new network configuration
                      DeviceConfiguration.NetworkConfigurationProperties newDeviceNetworkConfiguration = new DeviceConfiguration.NetworkConfigurationProperties
                      {
@@ -774,16 +836,35 @@ namespace Serial_Test_App_WPF
                      // write device configuration to device
                      var returnValue = device.DebugEngine.UpdateDeviceConfiguration(newDeviceNetworkConfiguration, 0);
 
-                     // add new wireless 802.11 configuration
-                     DeviceConfiguration.Wireless80211ConfigurationProperties newWireless80211Configuration = new DeviceConfiguration.Wireless80211ConfigurationProperties()
-                     {
-                         Id = 44,
-                         Ssid = "Nice_Ssid",
-                         Password = "1234",
-                     };
+                     //// add new wireless 802.11 configuration
+                     //DeviceConfiguration.Wireless80211ConfigurationProperties newWireless80211Configuration = new DeviceConfiguration.Wireless80211ConfigurationProperties()
+                     //{
+                     //    Id = 44,
+                     //    Ssid = "Nice_Ssid",
+                     //    Password = "1234",
+                     //};
 
-                     // write wireless configuration to device
-                     returnValue = device.DebugEngine.UpdateDeviceConfiguration(newWireless80211Configuration, 0);
+                     //// write wireless configuration to device
+                     //returnValue = device.DebugEngine.UpdateDeviceConfiguration(newWireless80211Configuration, 0);
+
+                     // build a CA certificate bundle
+                     DeviceConfiguration.X509CaRootBundleProperties newX509CertificateBundle = new DeviceConfiguration.X509CaRootBundleProperties();
+
+                     // add CA root certificates
+
+                     /////////////////////////////////////////////////////////
+                     // BECAUSE WE ARE PARSING FROM A BASE64 encoded format //
+                     // NEED TO ADD A TERMINATOR TO THE STRING              //
+                     /////////////////////////////////////////////////////////
+
+                     string caRootBundle = baltimoreCACertificate + letsEncryptCACertificate + "\0";
+
+                     byte[] certificateRaw = Encoding.UTF8.GetBytes(caRootBundle);
+
+                     newX509CertificateBundle.Certificate = certificateRaw;
+
+                     // write CA certificate to device
+                     returnValue = device.DebugEngine.UpdateDeviceConfiguration(newX509CertificateBundle, 0);
 
                      Debug.WriteLine("");
                      Debug.WriteLine("");

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/DeviceConfiguration.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/DeviceConfiguration.cs
@@ -35,6 +35,11 @@ namespace nanoFramework.Tools.Debugger
         /// </summary>
         public static string MarkerConfigurationWireless80211AP_v1 = "AP1\0";
 
+        /// <summary>
+        /// X509 CA Root bundle configuration marker
+        /// </summary>
+        public static string MarkerConfigurationX509CaRootBundle_v1 = "XB1\0";
+
         /////////////////////////////////////////////////////////////
 
         /// <summary>
@@ -47,19 +52,27 @@ namespace nanoFramework.Tools.Debugger
         /// </summary>
         public List<Wireless80211ConfigurationProperties> Wireless80211Configurations { get; set; }
 
+        /// <summary>
+        /// Collection of <see cref="Wireless80211ConfigurationProperties"/> blocks in a target device.
+        /// </summary>
+        public List<X509CaRootBundleProperties> X509Certificates { get; set; }
+
         public DeviceConfiguration()
             : this(new List<NetworkConfigurationProperties>(),
-                   new List<Wireless80211ConfigurationProperties>())
+                   new List<Wireless80211ConfigurationProperties>(),
+                   new List<X509CaRootBundleProperties>())
         {
         }
 
         public DeviceConfiguration(
             List<NetworkConfigurationProperties> networkConfiguratons,
-            List<Wireless80211ConfigurationProperties> networkWirelessConfiguratons
+            List<Wireless80211ConfigurationProperties> networkWirelessConfiguratons,
+            List<X509CaRootBundleProperties> x509Certificates
             )
         {
             NetworkConfigurations = networkConfiguratons;
             Wireless80211Configurations = networkWirelessConfiguratons;
+            X509Certificates = x509Certificates;
         }
 
         // operator to allow cast_ing a DeviceConfiguration object to DeviceConfigurationBase
@@ -68,7 +81,8 @@ namespace nanoFramework.Tools.Debugger
             return new DeviceConfigurationBase()
             {
                 NetworkConfigurations = value.NetworkConfigurations.Select(i => (NetworkConfigurationBase)i).ToArray(),
-                Wireless80211Configurations = value.Wireless80211Configurations.Select(i => (Wireless80211ConfigurationBase)i).ToArray()
+                Wireless80211Configurations = value.Wireless80211Configurations.Select(i => (Wireless80211ConfigurationBase)i).ToArray(),
+                X509CaRootBundle = value.X509Certificates.Select(i => (X509CaRootBundleBase)i).ToArray()
             };
         }
 
@@ -243,6 +257,41 @@ namespace nanoFramework.Tools.Debugger
                 return networkWirelessConfig;
             }
 
+        }
+
+
+        [AddINotifyPropertyChangedInterface]
+        public class X509CaRootBundleProperties : X509CaRootBundlePropertiesBase
+        {
+            public bool IsUnknown { get; set; } = true;
+
+            public X509CaRootBundleProperties()
+            {
+
+            }
+
+            public X509CaRootBundleProperties(X509CaRootBundleBase certificate)
+            {
+                CertificateSize = (uint)certificate.Certificate.Length;
+                Certificate = certificate.Certificate;
+
+                // reset unknown flag
+                IsUnknown = false;
+            }
+
+            // operator to allow cast_ing a X509CaRootBundleBaseProperties object to X509CaRootBundleBase
+            public static explicit operator X509CaRootBundleBase(X509CaRootBundleProperties value)
+            {
+                var x509Certificate = new X509CaRootBundleBase()
+                {
+                    Marker = Encoding.UTF8.GetBytes(MarkerConfigurationX509CaRootBundle_v1),
+
+                    CertificateSize = (uint)value.Certificate.Length,
+                    Certificate = value.Certificate,
+                };
+
+                return x509Certificate;
+            }
         }
 
         /////////////////////////////////////////////////////////////

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/DeviceConfigurationBase.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/DeviceConfigurationBase.cs
@@ -11,5 +11,7 @@ namespace nanoFramework.Tools.Debugger
         public NetworkConfigurationBase[] NetworkConfigurations;
 
         public Wireless80211ConfigurationBase[] Wireless80211Configurations { get; internal set; }
+
+        public X509CaRootBundleBase[] X509CaRootBundle { get; internal set; }
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/DeviceConfigurationOption.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/DeviceConfigurationOption.cs
@@ -32,6 +32,11 @@ namespace nanoFramework.Tools.Debugger
             WirelessNetworkAP = 3,
 
             /// <summary>
+            /// X509 Certificate block
+            /// </summary>
+            X509Certificate = 4,
+
+            /// <summary>
             /// All configuration blocks
             /// </summary>
             All = 255,

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/X509CaRootBundleBase.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/X509CaRootBundleBase.cs
@@ -1,0 +1,33 @@
+﻿//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Tools.Debugger
+{
+    public class X509CaRootBundleBase
+    {
+        /// <summary>
+        /// This is the marker placeholder for this configuration block
+        /// 4 bytes length.
+        /// </summary>
+        public byte[] Marker;
+
+        /// <summary>
+        /// Size of the certificate.
+        /// </summary>
+        public uint CertificateSize;
+
+        /// <summary>
+        /// Certificate
+        /// </summary>
+        public byte[] Certificate;
+
+        public X509CaRootBundleBase()
+        {
+            // need to init these here to match the expected size on the struct to be sent to the device
+            Marker = new byte[4];
+            Certificate = new byte[64];
+        }
+    }
+}

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/X509CaRootBundlePropertiesBase.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/X509CaRootBundlePropertiesBase.cs
@@ -1,0 +1,27 @@
+﻿//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using PropertyChanged;
+
+namespace nanoFramework.Tools.Debugger
+{
+    [AddINotifyPropertyChangedInterface]
+    public class X509CaRootBundlePropertiesBase
+    {
+        private byte[] _certificate;
+
+        public uint CertificateSize { get; set; }
+
+        public byte[] Certificate
+        {
+            get => _certificate;
+            set
+            {
+                _certificate = value;
+                CertificateSize = (uint)value.Length;
+            }
+        }
+    }
+}

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -335,6 +335,23 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                     Password = new byte[64];
                 }
             }
+
+            public class X509CaRootBundleConfig : X509CaRootBundleBase, IConverter
+            {
+                public X509CaRootBundleConfig()
+                {
+                    Marker = new byte[4];
+                    CertificateSize = 0xFFFF;
+                    Certificate = new byte[64];
+                }
+
+                public void PrepareForDeserialize(int size, byte[] data, Converter converter)
+                {
+                    Marker = new byte[4];
+                    CertificateSize = 0xFFFF;
+                    Certificate = new byte[size - 4 - 4];
+                }
+            }
         }
 
         public class Monitor_UpdateConfiguration
@@ -342,6 +359,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             public uint Configuration;
             public uint BlockIndex;
             public uint Length = 0;
+            public uint Offset = 0;
             public byte[] Data = null;
 
             public class Reply
@@ -349,12 +367,14 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 public uint ErrorCode;
             };
 
-            public void PrepareForSend(byte[] data, int length)
+            public void PrepareForSend(byte[] data, int length, int offset = 0)
             {
                 Length = (uint)length;
                 Data = new byte[length];
 
-                Array.Copy(data, 0, Data, 0, length);
+                Offset = (uint)offset;
+
+                Array.Copy(data, offset, Data, 0, length);
             }
         }
 

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/nanoFramework.Tools.DebugLibrary.Net.projitems
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/nanoFramework.Tools.DebugLibrary.Net.projitems
@@ -17,6 +17,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)DeviceConfiguration\DeviceConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeviceConfiguration\DeviceConfigurationBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeviceConfiguration\Wireless80211ConfigurationPropertiesBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DeviceConfiguration\X509CaRootBundleBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DeviceConfiguration\X509CaRootBundlePropertiesBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeviceConfiguration\Wireless80211Base.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeviceConfiguration\NetworkConfigurationPropertiesBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeviceConfiguration\NetworkConfigurationBase.cs" />


### PR DESCRIPTION
## Description
- Improve Monitor_UpdateConfiguration command to handle configuration blocks larger then the WP buffer size.
- Add new configuration block to store X509 certificates.


## Motivation and Context
- Need for the configuration block API to handle configuration blocks larger than the WP buffer size e.g. storing CA root certificates.

## How Has This Been Tested?<!-- (if applicable) -->
- Test app in the solution. Correctly performed update of config block with network config and a CA certificate.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
