### PR TITLE
Improve SerialDevice creation

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Shared/Extensions/TaskExtensions.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/Extensions/TaskExtensions.cs
@@ -3,6 +3,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace nanoFramework.Tools.Debugger.Extensions
@@ -24,6 +26,30 @@ namespace nanoFramework.Tools.Debugger.Extensions
         /// <param name="task"></param>
         public static void FireAndForget<T>(this Task<T> task)
         {
+        }
+
+        public static async Task<T> CancelAfterAsync<T>(this Task<T> task, int timeoutMilliseconds, CancellationTokenSource taskCts)
+        {
+            // sanity check for reasonable timeout values
+            if (timeoutMilliseconds < 0 || (timeoutMilliseconds > 0 && timeoutMilliseconds < 100))
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            var timerCts = new CancellationTokenSource();
+            if (await Task.WhenAny(task, Task.Delay(timeoutMilliseconds, timerCts.Token)) == task)
+            {
+                // task completed, get rid of timer
+                timerCts.Cancel();
+            }
+            else
+            {
+                // timer completed, cancel task
+                taskCts.Cancel();
+            }
+
+            // caller should test for exceptions or task cancellation
+            return await task;
         }
     }
 }


### PR DESCRIPTION
## Description
- Add extension to cancel task after timeout.
- Improve code to `SerialDevice.FromIdAsync` to handle execution blocking with faulty drivers and non returning calls.

## Motivation and Context
- Attempt to mitigate reported issues with device discovery with Bluetooth virtual serial ports and some ESP32 serial interfaces.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
