### PR TITLE
Fix FlashSectorData ToString

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Shared/Extensions/OutputExtensions.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/Extensions/OutputExtensions.cs
@@ -48,10 +48,15 @@ namespace nanoFramework.Tools.Debugger.Extensions
                     }
                     return output.ToString();
                 }
-            }
-            catch { }
 
-            return "Invalid or empty map data.";
+                return "Empty map data.";
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Exception when parsing memory map data: {ex.Message + Environment.NewLine + ex.StackTrace}");
+            }
+
+            return "Exception when trying to parse memory map data.";
         }
 
         public static string ToStringForOutput(this List<Commands.Monitor_FlashSectorMap.FlashSectorData> range)
@@ -82,12 +87,15 @@ namespace nanoFramework.Tools.Debugger.Extensions
                     output.AppendLine(" Start        Size (kB)           Usage");
                     output.AppendLine("--------------------------------------------");
 
-                    // nanoBooter
-                    output.AppendLine(
-                        $" {string.Format("0x{0:X08}", range.First(item => (item.m_flags & Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_MASK) == Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_BOOTSTRAP).m_StartAddress)}" +
-                        $"   {string.Format("0x{0:X06}", range.Where(item => (item.m_flags & Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_MASK) == Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_BOOTSTRAP).Sum(obj => obj.m_NumBlocks * obj.m_BytesPerBlock))}" +
-                        $" {range.Where(item => (item.m_flags & Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_MASK) == Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_BOOTSTRAP).Sum(obj => obj.m_NumBlocks * obj.m_BytesPerBlock).ToMemorySizeFormart()}" +
-                        $"   {range.First(item => (item.m_flags & Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_MASK) == Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_BOOTSTRAP).UsageAsString()}");
+                    // output nanoBooter, only if it's available on the target
+                    if (range.Exists(item => (item.m_flags & Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_MASK) == Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_BOOTSTRAP))
+                    {
+                        output.AppendLine(
+                            $" {string.Format("0x{0:X08}", range.First(item => (item.m_flags & Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_MASK) == Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_BOOTSTRAP).m_StartAddress)}" +
+                            $"   {string.Format("0x{0:X06}", range.Where(item => (item.m_flags & Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_MASK) == Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_BOOTSTRAP).Sum(obj => obj.m_NumBlocks * obj.m_BytesPerBlock))}" +
+                            $" {range.Where(item => (item.m_flags & Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_MASK) == Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_BOOTSTRAP).Sum(obj => obj.m_NumBlocks * obj.m_BytesPerBlock).ToMemorySizeFormart()}" +
+                            $"   {range.First(item => (item.m_flags & Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_MASK) == Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_BOOTSTRAP).UsageAsString()}");
+                    }
 
                     // output config line only if it's available on the target
                     if (range.Count(item => (item.m_flags & Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_MASK) == Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_CONFIG) > 0)
@@ -115,10 +123,15 @@ namespace nanoFramework.Tools.Debugger.Extensions
 
                     return output.ToString();
                 }
-            }
-            catch { }
 
-            return "Invalid or empty map data.";
+                return "Empty map data.";
+            }
+            catch(Exception ex)
+            {
+                Console.WriteLine($"Exception when parsing flash map data: {ex.Message + Environment.NewLine + ex.StackTrace}");
+            }
+
+            return "Exception when trying to parse flash map data.";
         }
 
         public static string ToStringForOutput(this List<Commands.Monitor_DeploymentMap.DeploymentData> range)


### PR DESCRIPTION
## Description
- Improve error messages for memory and flash maps.

## Motivation and Context
- Was throwing an hidden exception when trying to output line for nanoBooter on targets that don't have it.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
