### PR TITLE
Improvements device discovery and PortBase classes

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml
+++ b/source/USB Test App WPF/MainWindow.xaml
@@ -46,6 +46,7 @@
         <Button Content="Is Init State" HorizontalAlignment="Left" Margin="162,195,0,0" VerticalAlignment="Top" Width="75" Click="IsInitStateButton_Click" />
         <Button Content="Get Device Config" HorizontalAlignment="Left" Margin="378,275,0,0" VerticalAlignment="Top" Width="98" Click="GetDeviceConfigButton_Click" />
         <Button Content="Set Device Config" HorizontalAlignment="Left" Margin="378,313,0,0" VerticalAlignment="Top" Width="98" Click="SetDeviceConfigButton_Click" />
+        <Button Content="ReScan devices" HorizontalAlignment="Left" Margin="250,157,0,0" VerticalAlignment="Top" Width="98" Click="ReScanDevices_Click" />
 
 
     </Grid>

--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -143,24 +143,7 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 
         private async void PingButton_Click(object sender, RoutedEventArgs e)
         {
-            // disable button
-            (sender as Button).IsEnabled = false;
-
-            await Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() => {
-
-                var p = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].Ping();
-
-                Debug.WriteLine("");
-                Debug.WriteLine("");
-                Debug.WriteLine("Ping response: " + p.ToString());
-                Debug.WriteLine("");
-                Debug.WriteLine("");
-
-            }));
-
-            // enable button
-            (sender as Button).IsEnabled = true;
-        }
+}
 
         private object await(MainViewModel mainViewModel)
         {
@@ -405,14 +388,14 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
                 await Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() =>
                 {
 
-                    var result = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.DeploymentExecute(assemblies, false);
+                    var result = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.DeploymentExecute(assemblies, true);
 
                     Debug.WriteLine($">>> Deployment result: {result} <<<<");
 
 
-                    (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.RebootDevice(RebootOptions.ClrOnly);
+                    //(DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.RebootDevice(RebootOptions.ClrOnly);
 
-                    Task.Delay(1000).Wait();
+                    //Task.Delay(1000).Wait();
 
                     (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].GetDeviceInfo(true);
 
@@ -879,6 +862,21 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
                  }
 
              }));
+
+            // enable button
+            (sender as Button).IsEnabled = true;
+        }
+
+        private async void ReScanDevices_Click(object sender, RoutedEventArgs e)
+        {
+            // disable button
+            (sender as Button).IsEnabled = false;
+
+            await Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() => {
+
+                (DataContext as MainViewModel).SerialDebugService.SerialDebugClient.ReScanDevices();
+
+            }));
 
             // enable button
             (sender as Button).IsEnabled = true;

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortDefinitions/PortBase.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortDefinitions/PortBase.cs
@@ -59,6 +59,24 @@ namespace nanoFramework.Tools.Debugger
         /// </summary>
         public event EventHandler<StringEventArgs> LogMessageAvailable;
 
+        /// <summary>
+        /// Starts the device watchers.
+        /// If they are already started this operation won't have any effect.
+        /// </summary>
+        public abstract void StartDeviceWatchers();
+
+        /// <summary>
+        /// Stops the device watchers.
+        /// If they are already stopped this operation won't have any effect.
+        /// </summary>
+        public abstract void StopDeviceWatchers();
+
+        /// <summary>
+        /// Performs a re-scan of the connected devices.
+        /// This operation resets the list of available devices and attempts to validate if a connected device it's a nanoDevice.
+        /// </summary>
+        public abstract void ReScanDevices();
+
         public void OnLogMessageAvailable(string message)
         {
             LogMessageAvailable?.Invoke(this, new StringEventArgs(message));

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
@@ -52,7 +52,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
         /// <summary>
         /// Creates an Serial debug client
         /// </summary>
-        public SerialPort(object callerApp)
+        public SerialPort(object callerApp, bool startDeviceWatchers = true)
         {
             _mapDeviceWatchersToDeviceSelector = new Dictionary<DeviceWatcher, String>();
             NanoFrameworkDevices = new ObservableCollection<NanoDeviceBase>();
@@ -70,12 +70,17 @@ namespace nanoFramework.Tools.Debugger.PortSerial
             };
 
             Task.Factory.StartNew(() => {
-                StartSerialDeviceWatchers();
+
+                InitializeDeviceWatchers();
+
+                if (startDeviceWatchers)
+                {
+                    StartSerialDeviceWatchers();
+                }
             });
 
             ResetReadCancellationTokenSource();
             ResetSendCancellationTokenSource();
-
         }
 
 
@@ -102,6 +107,57 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
         #endregion
 
+        public override void ReScanDevices()
+        {
+            // clear the device list
+            var devicesToRemove = NanoFrameworkDevices.Select(nanoDevice => ((NanoDevice<NanoSerialDevice>)nanoDevice).Device.DeviceInformation.DeviceInformation.Id).ToList();
+            
+            foreach(var deviceId in devicesToRemove)
+            {
+                // get device...
+                var device = FindNanoFrameworkDevice(deviceId);
+
+                // ... and remove it from collection
+                NanoFrameworkDevices.Remove(device);
+
+                device?.DebugEngine?.StopProcessing();
+                device?.DebugEngine?.Dispose();
+            }
+            
+            // rebuild tentative list from serial devices list
+            foreach(var device in _serialDevices)
+            {
+                // Create a new element for this device and...
+                var newNanoFrameworkDevice = new NanoDevice<NanoSerialDevice>();
+                newNanoFrameworkDevice.Device.DeviceInformation = new SerialDeviceInformation(device.DeviceInformation, device.DeviceSelector);
+                newNanoFrameworkDevice.Parent = this;
+                newNanoFrameworkDevice.Transport = TransportType.Serial;
+
+                // ... add it to the collection of tentative devices
+                _tentativeNanoFrameworkDevices.Add(newNanoFrameworkDevice as NanoDeviceBase);
+            }
+
+            if(_tentativeNanoFrameworkDevices.Count > 0)
+            {
+                Task.Factory.StartNew(async () =>
+                {
+                    await ProcessDeviceEnumerationCompleteAsync();
+                }).FireAndForget();
+            }
+        }
+
+        public override void StartDeviceWatchers()
+        {
+            if(!_watchersStarted)
+            {
+                StartDeviceWatchersInternal();
+            }
+        }
+
+        public override void StopDeviceWatchers()
+        {
+            StopDeviceWatchersInternal();
+        }
 
         #region Device watcher management and host app status handling
 
@@ -137,14 +193,13 @@ namespace nanoFramework.Tools.Debugger.PortSerial
         public void StartSerialDeviceWatchers()
         {
             // Initialize the Serial device watchers to be notified when devices are connected/removed
-            InitializeDeviceWatchers();
-            StartDeviceWatchers();
+            StartDeviceWatchersInternal();
         }
 
         /// <summary>
         /// Starts all device watchers including ones that have been individually stopped.
         /// </summary>
-        private void StartDeviceWatchers()
+        private void StartDeviceWatchersInternal()
         {
             // Start all device watchers
             _watchersStarted = true;
@@ -188,14 +243,14 @@ namespace nanoFramework.Tools.Debugger.PortSerial
             if (_watchersSuspended)
             {
                 _watchersSuspended = false;
-                StartDeviceWatchers();
+                StartDeviceWatchersInternal();
             }
         }
 
         /// <summary>
         /// Stops all device watchers.
         /// </summary>
-        private void StopDeviceWatchers()
+        private void StopDeviceWatchersInternal()
         {
             // Stop all device watchers
             foreach (DeviceWatcher deviceWatcher in _mapDeviceWatchersToDeviceSelector.Keys)
@@ -209,6 +264,21 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
             // Clear the list of devices so we don't have potentially disconnected devices around
             ClearDeviceEntries();
+
+            // also clear nanoFramework devices list
+            var devicesToRemove = NanoFrameworkDevices.Select(nanoDevice => ((NanoDevice<NanoSerialDevice>)nanoDevice).Device.DeviceInformation.DeviceInformation.Id).ToList();
+
+            foreach (var deviceId in devicesToRemove)
+            {
+                // get device...
+                var device = FindNanoFrameworkDevice(deviceId);
+
+                // ... and remove it from collection
+                NanoFrameworkDevices.Remove(device);
+
+                device?.DebugEngine?.StopProcessing();
+                device?.DebugEngine?.Dispose();
+            }
 
             _watchersStarted = false;
         }
@@ -406,42 +476,47 @@ namespace nanoFramework.Tools.Debugger.PortSerial
             // add another device watcher completed
             _deviceWatchersCompletedCount++;
 
+            // check if we have them all to start post processing
             if (_deviceWatchersCompletedCount == _mapDeviceWatchersToDeviceSelector.Count)
             {
                 Task.Factory.StartNew(async () =>
                 {
-                    // prepare a list of devices that are to be removed if they are deemed as not valid nanoFramework devices
-                    var devicesToRemove = new List<NanoDeviceBase>();
-
-                    foreach (NanoDeviceBase device in _tentativeNanoFrameworkDevices)
-                    {
-                        var nFDeviceIsValid = await CheckValidNanoFrameworkSerialDeviceAsync(((NanoDevice<NanoSerialDevice>)device).Device.DeviceInformation).ConfigureAwait(true);
-
-                        if (nFDeviceIsValid)
-                        {
-                            OnLogMessageAvailable(NanoDevicesEventSource.Log.ValidDevice($"{device.Description} {(((NanoDevice<NanoSerialDevice>)device).Device.DeviceInformation.DeviceInformation.Id)}"));
-
-                            NanoFrameworkDevices.Add(device);
-                        }
-                        else
-                        {
-                            OnLogMessageAvailable(NanoDevicesEventSource.Log.QuitDevice(((NanoDevice<NanoSerialDevice>)device).Device.DeviceInformation.DeviceInformation.Id));
-                        }
-                    }
-
-                    // all watchers have completed enumeration
-                    IsDevicesEnumerationComplete = true;
-
-                    // clean list of tentative nanoFramework Devices
-                    _tentativeNanoFrameworkDevices.Clear();
-
-                    OnLogMessageAvailable(NanoDevicesEventSource.Log.SerialDeviceEnumerationCompleted(NanoFrameworkDevices.Count));
-
-                    // fire event that Serial enumeration is complete 
-                    OnDeviceEnumerationCompleted();
-
+                    await ProcessDeviceEnumerationCompleteAsync();
                 }).FireAndForget();
             }
+        }
+
+        private async Task ProcessDeviceEnumerationCompleteAsync()
+        {
+            // prepare a list of devices that are to be removed if they are deemed as not valid nanoFramework devices
+            var devicesToRemove = new List<NanoDeviceBase>();
+
+            foreach (NanoDeviceBase device in _tentativeNanoFrameworkDevices)
+            {
+                var nFDeviceIsValid = await CheckValidNanoFrameworkSerialDeviceAsync(((NanoDevice<NanoSerialDevice>)device).Device.DeviceInformation).ConfigureAwait(true);
+
+                if (nFDeviceIsValid)
+                {
+                    OnLogMessageAvailable(NanoDevicesEventSource.Log.ValidDevice($"{device.Description} {(((NanoDevice<NanoSerialDevice>)device).Device.DeviceInformation.DeviceInformation.Id)}"));
+
+                    NanoFrameworkDevices.Add(device);
+                }
+                else
+                {
+                    OnLogMessageAvailable(NanoDevicesEventSource.Log.QuitDevice(((NanoDevice<NanoSerialDevice>)device).Device.DeviceInformation.DeviceInformation.Id));
+                }
+            }
+
+            // all watchers have completed enumeration
+            IsDevicesEnumerationComplete = true;
+
+            // clean list of tentative nanoFramework Devices
+            _tentativeNanoFrameworkDevices.Clear();
+
+            OnLogMessageAvailable(NanoDevicesEventSource.Log.SerialDeviceEnumerationCompleted(NanoFrameworkDevices.Count));
+
+            // fire event that Serial enumeration is complete 
+            OnDeviceEnumerationCompleted();
         }
 
         private async Task<bool> CheckValidNanoFrameworkSerialDeviceAsync(SerialDeviceInformation deviceInformation)

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortUSB/UsbPort.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortUSB/UsbPort.cs
@@ -45,7 +45,7 @@ namespace nanoFramework.Tools.Debugger.Usb
         /// <summary>
         /// Creates an USB debug client
         /// </summary>
-        public UsbPort(Application callerApp)
+        public UsbPort(Application callerApp, bool startDeviceWatchers = true)
         {
             mapDeviceWatchersToDeviceSelector = new Dictionary<DeviceWatcher, String>();
             NanoFrameworkDevices = new ObservableCollection<NanoDeviceBase>();
@@ -59,7 +59,10 @@ namespace nanoFramework.Tools.Debugger.Usb
 
             Task.Factory.StartNew(() =>
             {
-                StartUsbDeviceWatchers();
+                if (startDeviceWatchers)
+                {
+                    StartUsbDeviceWatchers();
+                }
             });
         }
 
@@ -115,14 +118,13 @@ namespace nanoFramework.Tools.Debugger.Usb
         public void StartUsbDeviceWatchers()
         {
             // Initialize the USB device watchers to be notified when devices are connected/removed
-            InitializeDeviceWatchers();
-            StartDeviceWatchers();
+            StartDeviceWatchersInternal();
         }
 
         /// <summary>
         /// Starts all device watchers including ones that have been individually stopped.
         /// </summary>
-        private void StartDeviceWatchers()
+        private void StartDeviceWatchersInternal()
         {
             // Start all device watchers
             watchersStarted = true;
@@ -149,7 +151,7 @@ namespace nanoFramework.Tools.Debugger.Usb
             if (watchersStarted)
             {
                 watchersSuspended = true;
-                StopDeviceWatchers();
+                StopDeviceWatchersInternal();
             }
             else
             {
@@ -173,7 +175,7 @@ namespace nanoFramework.Tools.Debugger.Usb
         /// <summary>
         /// Stops all device watchers.
         /// </summary>
-        private void StopDeviceWatchers()
+        private void StopDeviceWatchersInternal()
         {
             // Stop all device watchers
             foreach (DeviceWatcher deviceWatcher in mapDeviceWatchersToDeviceSelector.Keys)
@@ -628,6 +630,21 @@ namespace nanoFramework.Tools.Debugger.Usb
 
             // return empty byte array
             return new byte[0];
+        }
+
+        public override void StartDeviceWatchers()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void StopDeviceWatchers()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void ReScanDevices()
+        {
+            throw new NotImplementedException();
         }
 
         #endregion

--- a/source/nanoFramework.Tools.DebugLibrary.UWP/PortDefinitions/PortBase.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.UWP/PortDefinitions/PortBase.cs
@@ -13,14 +13,14 @@ namespace nanoFramework.Tools.Debugger
 {
     public abstract partial class PortBase
     {
-        public static PortBase CreateInstanceForSerial(string displayName, Application callerApp)
+        public static PortBase CreateInstanceForSerial(string displayName, Application callerApp, bool startDeviceWatchers = true)
         {
-            return new SerialPort(callerApp);
+            return new SerialPort(callerApp, startDeviceWatchers);
         }
 
-        public static PortBase CreateInstanceForUsb(string displayName, Application callerApp)
+        public static PortBase CreateInstanceForUsb(string displayName, Application callerApp, bool startDeviceWatchers = true)
         {
-            return new UsbPort(callerApp);
+            return new UsbPort(callerApp, startDeviceWatchers);
         }
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.UWP/PortSerial/SerialPort.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.UWP/PortSerial/SerialPort.cs
@@ -25,7 +25,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
         /// <summary>
         /// Creates an Serial debug client
         /// </summary>
-        public SerialPort(Application callerApp)
+        public SerialPort(Application callerApp, bool startDeviceWatchers = true)
         {
             _mapDeviceWatchersToDeviceSelector = new Dictionary<DeviceWatcher, String>();
             NanoFrameworkDevices = new ObservableCollection<NanoDeviceBase>();
@@ -36,7 +36,10 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
             Task.Factory.StartNew(() =>
             {
-                StartSerialDeviceWatchers();
+                if (startDeviceWatchers)
+                {
+                    StartSerialDeviceWatchers();
+                }
             });
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Improve check of nanoBooter on device discovery: the code now checks for a valid marker in the received packet.
- PortBase class now has methods to Start and stop the device watchers and also to rescan devices.
- SerialPort and UsbPort now have an overloaded constructor allowing to instanciate the class without starting the device watchers.
- Update test app.

## Motivation and Context
- Improves device discovery.
- Improves developer experience allowing VS to start debugger component with or without device watchers started.
- Improves developer experience allowing VS to rescan devices without forcing developer to physically unplug and plug nanoDevices that are behind a serial converter.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
