### PR TITLE
Update CreateInstanceForSerial constructor for .NET lib

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Net/PortDefinitions/PortBase.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/PortDefinitions/PortBase.cs
@@ -9,9 +9,9 @@ namespace nanoFramework.Tools.Debugger
 {
     public abstract partial class PortBase
     {
-        public static PortBase CreateInstanceForSerial(string displayName, object callerApp = null)
+        public static PortBase CreateInstanceForSerial(string displayName, object callerApp = null, bool startDeviceWatchers = true)
         {
-            return new SerialPort(callerApp);
+            return new SerialPort(callerApp, startDeviceWatchers);
         }
     }
 }


### PR DESCRIPTION
## Description

## Motivation and Context
- .NET version was missing the new CreateInstanceForSerial constructor.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
