### PR TITLE
Work on ReadMemory command

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml
+++ b/source/USB Test App WPF/MainWindow.xaml
@@ -47,6 +47,7 @@
         <Button Content="Get Device Config" HorizontalAlignment="Left" Margin="378,275,0,0" VerticalAlignment="Top" Width="98" Click="GetDeviceConfigButton_Click" />
         <Button Content="Set Device Config" HorizontalAlignment="Left" Margin="378,313,0,0" VerticalAlignment="Top" Width="98" Click="SetDeviceConfigButton_Click" />
         <Button Content="ReScan devices" HorizontalAlignment="Left" Margin="250,157,0,0" VerticalAlignment="Top" Width="98" Click="ReScanDevices_Click" />
+        <Button Content="Read Test" HorizontalAlignment="Left" Margin="162,313,0,0" VerticalAlignment="Top" Width="75" Click="ReadTestButton_Click" />
 
 
     </Grid>

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -7,12 +7,40 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.NetworkInformation;
 using System.Runtime.Serialization;
 using System.Text;
 
 namespace nanoFramework.Tools.Debugger.WireProtocol
 {
+    public enum AccessMemoryErrorCodes : uint
+    {
+        ////////////////////////////////////////////////////////////////////////////////////////
+        // NEED TO KEEP THESE IN SYNC WITH native 'AccessMemoryErrorCodes' enum in Debugger.h //
+        ////////////////////////////////////////////////////////////////////////////////////////
+
+        /// <summary>
+        /// No error
+        /// </summary>
+        NoError = 0x0000,
+
+        /// <summary>
+        /// Permission denied
+        /// </summary>
+        PermissionDenied = 0x0010,
+
+        /// <summary>
+        /// Failed to allocate buffer to execute operation
+        /// </summary>
+        FailedToAllocateReadBuffer = 0x0020,
+
+        /// <summary>
+        /// Breakpoints are disabled in the device
+        /// </summary>
+        RequestedOperationFailed = 0x0030,
+
+        Unknown = 0xFFFF,
+    }
+
     public class Commands
     {
         public const uint c_Monitor_Ping = 0x00000000; // The payload is empty, this command is used to let the other side know we are here...
@@ -139,11 +167,15 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
             public class Reply : IConverter
             {
+                public uint ErrorCode;
                 public byte[] m_data = null;
 
                 public void PrepareForDeserialize(int size, byte[] data, Converter converter)
                 {
-                    m_data = new byte[size];
+                    ErrorCode = 0;
+
+                    // buffer length is: size - sizeof(ErrorCode)
+                    m_data = new byte[size - 4];
                 }
             }
         }


### PR DESCRIPTION
## Description
- Add ErrorCode field to Monitor_ReadMemory.Reply class.
- Update deserializer method accordingly.
- Add enum with error codes for access memory operations.
- Rework Engine.ReadMemory() methods to add operation error code.
- Rework Engine.ReadMemory() method to improve processing of reply.
- Update test app to verify command functionality.


## Motivation and Context
- ReadMemory command wasn't working properly. 
- Needed the command to be able to read BOOTLOADER and CLR regions to improve VS extension features. 

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
