### PR TITLE
Add support for type resolution failed flag

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -200,7 +200,7 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
             (sender as Button).IsEnabled = false;
 
             await Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() =>
-             {
+            {
 
                  try
                  {
@@ -227,8 +227,16 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
                      }
                      else if ((deviceState & Commands.DebuggingExecutionChangeConditions.State.ProgramExited) == Commands.DebuggingExecutionChangeConditions.State.ProgramExited)
                      {
-                         Debug.WriteLine($">>> Device it's idle after exiting from a program execution <<<<");
+                         if ((deviceState & Commands.DebuggingExecutionChangeConditions.State.ResolutionFailed) == Commands.DebuggingExecutionChangeConditions.State.ResolutionFailed)
+                         {
+                             Debug.WriteLine($">>> Device can't start execution because type resolution has failed <<<<");
+                         }
+                         else
+                         {
+                             Debug.WriteLine($">>> Device it's idle after exiting from a program execution <<<<");
+                         }
                      }
+
                  }
                  catch
                  {

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/Extensions/DebuggerExtensions.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/Extensions/DebuggerExtensions.cs
@@ -81,6 +81,29 @@ namespace nanoFramework.Tools.Debugger.Extensions
             }
         }
 
+        /// <summary>
+        /// Check if device execution state is: stopped on type resolution failed.
+        /// </summary>
+        /// <param name="debugEngine"></param>
+        /// <returns></returns>
+        public static bool IsDeviceStoppedOnTypeResolutionFailed(this Engine debugEngine)
+        {
+            var result = debugEngine.GetExecutionMode();
+
+            if (result != WireProtocol.Commands.DebuggingExecutionChangeConditions.State.Unknown)
+            {
+                var filteredResult = result & WireProtocol.Commands.DebuggingExecutionChangeConditions.State.ResolutionFailed;
+
+                Debug.WriteLine($"Device state is: {filteredResult.OutputDeviceExecutionState()}.");
+
+                return (filteredResult == WireProtocol.Commands.DebuggingExecutionChangeConditions.State.ResolutionFailed);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
         internal static string OutputDeviceExecutionState(this WireProtocol.Commands.DebuggingExecutionChangeConditions.State state)
         {
             if (state == WireProtocol.Commands.DebuggingExecutionChangeConditions.State.Unknown)
@@ -104,7 +127,14 @@ namespace nanoFramework.Tools.Debugger.Extensions
             }
             else if ((state & WireProtocol.Commands.DebuggingExecutionChangeConditions.State.ProgramExited) == WireProtocol.Commands.DebuggingExecutionChangeConditions.State.ProgramExited)
             {
-               return "idle after exiting a program execution or start-up failure";
+                if ((state & WireProtocol.Commands.DebuggingExecutionChangeConditions.State.ResolutionFailed) == WireProtocol.Commands.DebuggingExecutionChangeConditions.State.ResolutionFailed)
+                {
+                    return "couldn't start execution because type resolution has failed";
+                }
+                else
+                {
+                    return "idle after exiting a program execution or start-up failure";
+                }
             }
 
             // should NEVER get here

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -514,6 +514,11 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 Initialize =            0x00000000,
 
                 /// <summary>
+                /// Type resolution has failed
+                /// </summary>
+                ResolutionFailed =      0x00000001,
+
+                /// <summary>
                 /// Device has a program running
                 /// </summary>
                 ProgramRunning =        0x00000400,

--- a/source/version.json
+++ b/source/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.2-preview.{height}",
+  "version": "1.1.0-preview.{height}",
   "buildNumberOffset": 10,
   "assemblyVersion": {
     "precision": "revision"


### PR DESCRIPTION

## Description
- Add debug state flag: ResolutionFailed.
- Add device state extension to process this flag.
- Add code to the test app.
- Bump version to 1.1.0-preview.
- Change version config to use semver 2.

## Motivation and Context
- This flag has been added to the interpreter for some time but never got any support in the debugger.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

