### PR TITLE
Add PlatformCapabilities and TargetCapabilities to CLRCapabilities

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -329,6 +329,16 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
                          Debug.WriteLine(string.Empty);
                          Debug.WriteLine(deviceDeploymentMap.ToString());
 
+                         Debug.WriteLine(string.Empty);
+                         Debug.WriteLine(string.Empty);
+                         Debug.WriteLine($"Target capabilities: { deviceInfo.TargetCapabilities }");
+
+                         Debug.WriteLine(string.Empty);
+                         Debug.WriteLine(string.Empty);
+                         Debug.WriteLine($"Platform capabilities: { deviceInfo.PlatformCapabilities }");
+
+                         Debug.WriteLine(string.Empty);
+                         Debug.WriteLine(string.Empty);
                      }
                      else
                      {

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/CLRCapabilities.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/CLRCapabilities.cs
@@ -12,6 +12,16 @@ namespace nanoFramework.Tools.Debugger
 {
     public class CLRCapabilities
     {
+        /// <summary>
+        /// Value of rotate right operation to get the platform capabilities as an integer.
+        /// </summary>
+        private static int s_platformCapabilitiesPosition = 16;
+
+        /// <summary>
+        /// Value of rotate right operation to get the target capabilities as an integer.
+        /// </summary>
+        private static int s_targetCapabilitiesPosition = 18;
+
         [Flags]
         public enum Capability : ulong
         {
@@ -36,7 +46,21 @@ namespace nanoFramework.Tools.Debugger
             /// This flag indicates that the device has nanoBooter.
             /// </summary>
             HasNanoBooter = 0x00001000,
-    }
+
+            /// <summary>
+            /// These bits are generic and are meant to be used to store platform specific capabilities.
+            /// They should be parsed at the above layer to extract the real meaning out of them.
+            /// </summary>
+            PlatformCapabiliy_0 = 0x00010000,
+            PlatformCapabiliy_1 = 0x00020000,
+
+            /// <summary>
+            /// These bits are generic and are meant to be used to store target specific capabilities.
+            /// They should be parsed at the above layer to extract the real meaning out of them.
+            /// </summary>
+            TargetCapabiliy_0 = 0x00040000,
+            TargetCapabiliy_1 = 0x00080000,
+        }
 
         public struct SoftwareVersionProperties
         {
@@ -344,6 +368,29 @@ namespace nanoFramework.Tools.Debugger
             {
                 Debug.Assert(!m_fUnknown);
                 return (m_capabilities & Capability.HasNanoBooter) != 0;
+            }
+        }
+
+        public byte PlatformCapabilities
+        {
+            get
+            {
+                Debug.Assert(!m_fUnknown);
+                var platformCapabilites = (ulong)(m_capabilities & (Capability.PlatformCapabiliy_0 | Capability.PlatformCapabiliy_1));
+                var value = platformCapabilites >> s_platformCapabilitiesPosition;
+                return (byte)value;
+            }
+        }
+
+
+        public byte TargetCapabilities
+        {
+            get
+            {
+                Debug.Assert(!m_fUnknown);
+                var targetCapabilites = (ulong)(m_capabilities & (Capability.TargetCapabiliy_0 | Capability.TargetCapabiliy_1));
+                var value = targetCapabilites >> s_targetCapabilitiesPosition;
+                return (byte)value;
             }
         }
 

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/Capabilities/Esp32.TargetCapabilities.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/Capabilities/Esp32.TargetCapabilities.cs
@@ -1,0 +1,19 @@
+﻿//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Tools.Debugger
+{
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // !!! KEEP IN SYNC WITH platform_target_capabilities.h (in nf-interpreter inside the platform folder) //
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    public partial class Esp32
+    {
+        public enum TargetCapabilities : byte
+        {
+            // This platform has no declared target capabilities
+        }
+    }
+}

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/Capabilities/Nxp.TargetCapabilities.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/Capabilities/Nxp.TargetCapabilities.cs
@@ -1,0 +1,19 @@
+﻿//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Tools.Debugger
+{
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // !!! KEEP IN SYNC WITH platform_target_capabilities.h (in nf-interpreter inside the platform folder) //
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    public partial class Nxp
+    {
+        public enum TargetCapabilities : byte
+        {
+            // This platform has no declared target capabilities
+        }
+    }
+}

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/Capabilities/Stm32.TargetCapabilities.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/Capabilities/Stm32.TargetCapabilities.cs
@@ -1,0 +1,21 @@
+﻿//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Tools.Debugger
+{
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // !!! KEEP IN SYNC WITH platform_target_capabilities.h (in nf-interpreter inside the platform folder) //
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    public partial class Stm32
+    {
+        public enum TargetCapabilities : byte
+        {
+            JtagUpdate  = 0,
+
+            DfuUpdate   = 1,
+        }
+    }
+}

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/Capabilities/TICC32xx.TargetCapabilities.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/Capabilities/TICC32xx.TargetCapabilities.cs
@@ -1,0 +1,19 @@
+﻿//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Tools.Debugger
+{
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // !!! KEEP IN SYNC WITH platform_target_capabilities.h (in nf-interpreter inside the platform folder) //
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    public partial class TiCC32xx
+    {
+        public enum TargetCapabilities : byte
+        {
+            // This platform has no declared target capabilities
+        }
+    }
+}

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/INanoFrameworkDeviceInfo.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/INanoFrameworkDeviceInfo.cs
@@ -28,5 +28,7 @@ namespace nanoFramework.Tools.Debugger
         IAppDomainInfo[] AppDomains { get; }
         IAssemblyInfo[] Assemblies { get; }
         List<CLRCapabilities.NativeAssemblyProperties> NativeAssemblies { get; }
+        byte PlatformCapabilities { get; }
+        byte TargetCapabilities { get; }
     }
 }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/NanoFrameworkDeviceInfo.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/NanoFrameworkDeviceInfo.cs
@@ -188,6 +188,16 @@ namespace nanoFramework.Tools.Debugger
             get { return Dbg.Capabilities.SolutionReleaseInfo.Platform; }
         }
 
+        public byte PlatformCapabilities
+        {
+            get { return Dbg.Capabilities.PlatformCapabilities; }
+        }
+
+        public byte TargetCapabilities
+        {
+            get { return Dbg.Capabilities.TargetCapabilities; }
+        }
+
         public IAppDomainInfo[] AppDomains
         {
             get { return m_Domains.ToArray(); }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/nanoFramework.Tools.DebugLibrary.Net.projitems
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/nanoFramework.Tools.DebugLibrary.Net.projitems
@@ -10,6 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)BitStream.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Capabilities\Nxp.TargetCapabilities.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Capabilities\TiCC32xx.TargetCapabilities.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Capabilities\Esp32.TargetCapabilities.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Capabilities\Stm32.TargetCapabilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CLRCapabilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CRC32.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DebuggerEventSource.cs" />


### PR DESCRIPTION
## Description
- Add these to NanoFrameworkDeviceInfo and interface.
- Add target capabilites enum for all available platforms.
- Update test app with these.

## Motivation and Context
- With these new data fields targets can report capabilities specific to the platform and to the target. Having them as general flags wouldn't work as that would be a waste of space because of the differences between platforms and targets. Having them generic allows for those differences and the real meaning is figured out by an upper layer. 

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
