### PR TITLE
Update serial baud rate to 921600

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Net/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/PortSerial/EventHandlerForSerialDevice.cs
@@ -126,7 +126,7 @@ namespace nanoFramework.Tools.Debugger.Serial
                     _deviceSelector = deviceSelector;
 
                     // adjust settings for serial port
-                    _device.BaudRate = 115200;
+                    _device.BaudRate = 921600;
                     _device.DataBits = 8;
 
                     /////////////////////////////////////////////////////////////

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
@@ -544,7 +544,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                 if (tentativeDevice != null)
                 {
                     // adjust settings for serial port
-                    tentativeDevice.BaudRate = 115200;
+                    tentativeDevice.BaudRate = 921600;
                     tentativeDevice.DataBits = 8;
 
                     /////////////////////////////////////////////////////////////

--- a/source/nanoFramework.Tools.DebugLibrary.UWP/PortSerial/EventHandlerForSerialDevice.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.UWP/PortSerial/EventHandlerForSerialDevice.cs
@@ -145,7 +145,7 @@ namespace nanoFramework.Tools.Debugger.Serial
                     NanoDevicesEventSource.Log.OpenDevice(_deviceInformation.Id);
 
                     // adjust settings for serial port
-                    _device.BaudRate = 115200;
+                    _device.BaudRate = 921600;
                     _device.DataBits = 8;
 
                     /////////////////////////////////////////////////////////////

--- a/source/version.json
+++ b/source/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2.1-preview.{height}",
+  "version": "1.3.0-preview.{height}",
   "buildNumberOffset": 10,
   "assemblyVersion": {
     "precision": "revision"


### PR DESCRIPTION
## Description
- Update configuration for serial baud rate to 921600.
- Bump version to 1.3.0-preview.

## Motivation and Context
- All current targets support this baud rate without any problem. This increases Wire Protocol throughput ~8x.
- Transport is actually performed with USB, serial is only used on very short distance on the board, meaning that no transmission issue will raise from this. Even if that's the case the WP layer has error checking mechanism that can be used to detect this, if needed.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
