### PR TITLE
Improve serial target detection

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPort.cs
@@ -3,18 +3,13 @@
 // See LICENSE file in the project root for full license information.
 //
 using nanoFramework.Tools.Debugger.Extensions;
-using nanoFramework.Tools.Debugger.Serial;
-using nanoFramework.Tools.Debugger.WireProtocol;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Devices.Enumeration;
 using Windows.Devices.SerialCommunication;
-using Windows.Foundation;
 using Windows.Storage.Streams;
 
 namespace nanoFramework.Tools.Debugger.PortSerial
@@ -29,6 +24,11 @@ namespace nanoFramework.Tools.Debugger.PortSerial
         private readonly SerialPortManager _portManager;
 
         public SerialDevice Device { get; internal set; }
+
+        // valid baud rates
+        public static readonly List<uint> ValidBaudRates = new List<uint>() { 921600, 460800, 115200 };
+
+        public uint BaudRate { get; internal set; }
 
         public NanoDevice<NanoSerialDevice> NanoDevice { get; }
 
@@ -59,6 +59,9 @@ namespace nanoFramework.Tools.Debugger.PortSerial
         {
             _portManager = portManager ?? throw new ArgumentNullException(nameof(portManager));
             NanoDevice = serialDevice ?? throw new ArgumentNullException(nameof(serialDevice));
+
+            // init default baud rate with 1st value
+            BaudRate =  ValidBaudRates[0];
 
             ResetReadCancellationTokenSource();
             ResetSendCancellationTokenSource();
@@ -98,7 +101,8 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                     successfullyOpenedDevice = true;
 
                     // adjust settings for serial port
-                    Device.BaudRate = 921600;
+                    // baud rate is coming from the property
+                    Device.BaudRate = BaudRate;
                     Device.DataBits = 8;
 
                     /////////////////////////////////////////////////////////////

--- a/source/version.json
+++ b/source/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4.0-preview.{height}",
+  "version": "1.5.0-preview.{height}",
   "buildNumberOffset": 10,
   "assemblyVersion": {
     "precision": "revision"


### PR DESCRIPTION
## Description
- On serial devices we are now attempting connecting with three different baud rates.
- Supported baud rates are: 921600, 460800, 115200.
- Bump version to 1.5.0-preview.

## Motivation and Context
- This is to accommodate targets connected through serial with low specs that can't perform that well with high baud rates.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
