### PR TITLE
Implement paged request of assemblies available in the target

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -821,6 +821,11 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             }
         }
 
+
+        //////////////////////////////////////////////////////////////////////////////////////
+        // Keep in sync with Debugging_Execution_QueryCLRCapabilities struct in native code //
+        //////////////////////////////////////////////////////////////////////////////////////
+
         public class Debugging_Execution_QueryCLRCapabilities
         {
             public const uint c_CapabilityFlags = 1;
@@ -830,6 +835,12 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             public const uint c_CapabilityClrInfo = 6;
             public const uint c_CapabilitySolutionReleaseInfo = 7;
             public const uint c_CapabilityInteropNativeAssemblies = 8;
+
+            ///////////////////////////////////////////////////////////
+            // because the number of deployed assemblies can make the size of the Wire Protocol package grow beyond the 
+            // target max packet size, need to be able to query the assemblies in batches
+            // at the same time need to keep backwards compatibility with the existing targets.
+            public const uint c_CapabilityInteropNativeAssembliesCount = 9;
 
             public const uint c_CapabilityFlags_FloatingPort = 0x00000001;
             public const uint c_CapabilityFlags_SourceLevelDebugging = 0x00000002;
@@ -913,6 +924,11 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
             public class NativeAssemblyDetails
             {
+                /// <summary>
+                /// size of NativeAssemblyDetails struct (4 + 4 * 2 + 128 * 1)
+                /// </summary>
+                public const int Size = (4 + 4 * 2 + 128 * 1);
+
                 // the fields bellow have to follow the exact type and order so that the reply of the device can be properly parsed
 
                 /////////////////////////////////////////////////////////////////////////////////////////
@@ -941,8 +957,8 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 public void PrepareForDeserialize(int size, byte[] data, Converter converter)
                 {
                     // find out how many items are in the reply array 
-                    // size of the reply buffer divided by the size of NativeAssemblyDetails struct (4 + 4 * 2 + 128 * 1)
-                    int numOfAssemblies = size / (4 + 4 * 2 + 128 * 1);
+                    // size of the reply buffer divided by the size of NativeAssemblyDetails struct
+                    int numOfAssemblies = size / NativeAssemblyDetails.Size;
 
                     NativeInteropAssemblies = Enumerable.Range(0, numOfAssemblies).Select(x => new NativeAssemblyDetails()).ToList();
                 }

--- a/source/version.json
+++ b/source/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.6.0-preview.{height}",
+  "version": "1.7.0-preview.{height}",
   "buildNumberOffset": 10,
   "assemblyVersion": {
     "precision": "revision"


### PR DESCRIPTION
## Description
- Add new command to Debugging_Execution_QueryCLRCapabilities to query assemblies count.
- Rework DiscoveryInteropNativeAssemblies() to make use of new command and keep backwards compatibility with older targets.
- Move "magic number" with NativeAssemblyDetails struct size to a constant in the struct.
- Update code accordingly.
- Bump version to 1.7.0-preview.

## Motivation and Context
- With the current implementation the assemblies listing of the target was received in a single batch. This could cause issues on targets with a large number of assemblies, because of the extra time in processing the packet through CRC32 calculation and sending a large packet over the Wire Protocol channel (can easily reach 2/3k !!).
- With a paged query of the assemblies we now respect the max packet size announced by the target and keep this working smoothly.
- The implementation takes care of making it backwards compatible with targets that do not implement the new command/processing (it will be safe to remove this code bit sometime in the future).

## How Has This Been Tested?<!-- (if applicable) -->
- UWP test app.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>