### PR TITLE
Revert some changes in detection workflow

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Net/PortDefinitions/PortBase.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/PortDefinitions/PortBase.cs
@@ -9,7 +9,7 @@ namespace nanoFramework.Tools.Debugger
 {
     public abstract partial class PortBase : PortMessageBase
     {
-        public static PortBase CreateInstanceForSerial(string displayName, object callerApp = null, bool startDeviceWatchers = true, int bootTime = 1500)
+        public static PortBase CreateInstanceForSerial(string displayName, object callerApp = null, bool startDeviceWatchers = true, int bootTime = 1000)
         {
             return new SerialPortManager(callerApp, startDeviceWatchers, bootTime);
         }


### PR DESCRIPTION
## Description
- Revert some changes and add back the second attempt to communicate with device.
- Decrease boot time to 1000ms.

## Motivation and Context
- The second attempt seems to be the best way to deal with dual USB devices.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
