### PR TITLE
General improvements with serial devices

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Shared/NanoDevicesEventSource.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/NanoDevicesEventSource.cs
@@ -12,6 +12,9 @@ namespace nanoFramework.Tools.Debugger
     [EventSource(Name = "nanoFramework-NanoDevices")]
     internal class NanoDevicesEventSource : EventSource
     {
+        private const string GUID_DEVINTERFACE_COMPORT = "{86e0d1e0-8089-11d0-9ce4-08003e301f73}";
+        private const string DEVICE_INSTANCE = "#0000#";
+
         public static NanoDevicesEventSource Log { get { return Log_.Value; } }
         private static readonly Lazy<NanoDevicesEventSource> Log_ = new Lazy<NanoDevicesEventSource>(() => new NanoDevicesEventSource());
 
@@ -28,7 +31,7 @@ namespace nanoFramework.Tools.Debugger
         [Event(2, Level = EventLevel.Informational, Opcode = EventOpcode.Info)]
         public string DeviceArrival(string deviceId)
         {
-            string logMessage = $"NanoDevices: new device arrival {deviceId} ";
+            string logMessage = $"NanoDevices: new device arrival {deviceId.Replace(GUID_DEVINTERFACE_COMPORT, "").Replace(DEVICE_INSTANCE, "")} ";
 
             WriteEvent(2, logMessage);
 
@@ -38,7 +41,7 @@ namespace nanoFramework.Tools.Debugger
         [Event(3, Level = EventLevel.Informational, Opcode = EventOpcode.Info)]
         public string CandidateDevice(string deviceId)
         {
-            string logMessage = $"NanoDevices: candidate nano device {deviceId}";
+            string logMessage = $"NanoDevices: candidate nano device {deviceId.Replace(GUID_DEVINTERFACE_COMPORT, "").Replace(DEVICE_INSTANCE, "")}";
 
             WriteEvent(3, logMessage);
 
@@ -48,7 +51,7 @@ namespace nanoFramework.Tools.Debugger
         [Event(4, Level = EventLevel.Informational, Opcode = EventOpcode.Info)]
         public string ValidDevice(string deviceId)
         {
-            string logMessage = $"NanoDevices: valid device {deviceId}";
+            string logMessage = $"NanoDevices: valid device {deviceId.Replace(GUID_DEVINTERFACE_COMPORT, "").Replace(DEVICE_INSTANCE, "")}";
 
             WriteEvent(4, logMessage);
 
@@ -68,7 +71,7 @@ namespace nanoFramework.Tools.Debugger
         [Event(6, Level = EventLevel.Informational, Opcode = EventOpcode.Info)]
         public string CheckingValidDevice(string deviceId)
         {
-            string logMessage = $"NanoDevices: checking device {deviceId}";
+            string logMessage = $"NanoDevices: checking device {deviceId.Replace(GUID_DEVINTERFACE_COMPORT, "").Replace(DEVICE_INSTANCE, "")}";
 
             WriteEvent(6, logMessage);
 
@@ -88,7 +91,7 @@ namespace nanoFramework.Tools.Debugger
         [Event(8, Level = EventLevel.Informational, Opcode = EventOpcode.Info)]
         public string QuitDevice(string deviceId)
         {
-            string logMessage = $"NanoDevices: quitting device {deviceId}";
+            string logMessage = $"NanoDevices: quitting device {deviceId.Replace(GUID_DEVINTERFACE_COMPORT, "").Replace(DEVICE_INSTANCE, "")}";
 
             WriteEvent(8, logMessage);
 
@@ -98,7 +101,7 @@ namespace nanoFramework.Tools.Debugger
         [Event(8, Level = EventLevel.Informational, Opcode = EventOpcode.Info)]
         public string OpenDevice(string deviceId)
         {
-            string logMessage = $"NanoDevices: open device {deviceId}";
+            string logMessage = $"NanoDevices: open device {deviceId.Replace(GUID_DEVINTERFACE_COMPORT, "").Replace(DEVICE_INSTANCE, "")}";
 
             WriteEvent(8, logMessage);
 
@@ -108,7 +111,7 @@ namespace nanoFramework.Tools.Debugger
         [Event(9, Level = EventLevel.Informational, Opcode = EventOpcode.Info)]
         public string CloseDevice(string deviceId)
         {
-            string logMessage = $"NanoDevices: close device {deviceId}";
+            string logMessage = $"NanoDevices: close device {deviceId.Replace(GUID_DEVINTERFACE_COMPORT, "").Replace(DEVICE_INSTANCE, "")}";
 
             WriteEvent(9, logMessage);
 
@@ -128,7 +131,7 @@ namespace nanoFramework.Tools.Debugger
         [Event(11, Level = EventLevel.Informational, Opcode = EventOpcode.Info)]
         public string DeviceDeparture(string deviceId)
         {
-            string logMessage = $"NanoDevices: device departure {deviceId} ";
+            string logMessage = $"NanoDevices: device departure {deviceId.Replace(GUID_DEVINTERFACE_COMPORT, "").Replace(DEVICE_INSTANCE, "")} ";
 
             WriteEvent(11, logMessage);
 

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/MessageReassembler.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/MessageReassembler.cs
@@ -147,6 +147,13 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
                                     if (_messageBase.Header.Size != 0)
                                     {
+                                        // sanity check for wrong size (can happen with CRC32 turned off)
+                                        if(_messageBase.Header.Size > 2048)
+                                        {
+                                            Debug.WriteLine("Invalid payload requested. Initializing.");
+
+                                            _state = ReceiveState.Initialize;
+                                        }
                                         _messageRaw.Payload = new byte[_messageBase.Header.Size];
                                         //reuse m_rawPos for position in header to read.
                                         _rawPos = 0;


### PR DESCRIPTION
## Description
- Add sanity check for payload size.
- Debug output of device IDs now are striped of the GUID of COM port device interfaces and device instance index (that show in composite USB devices).

## Motivation and Context
- On initial stage when the CRC23 in Wire Protocol is not active, a bad packet header could request payloads of impossible length causing out of memory exceptions. Now it's limited to twice the WP packet size.
- Improve debug output messages by removing "noise" from useless data.

## How Has This Been Tested?<!-- (if applicable) -->
- WPF test app.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
