### PR TITLE
ConnectAsync now requests device capabilies optionally

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -143,7 +143,11 @@ namespace nanoFramework.Tools.Debugger
 
         public bool StopDebuggerOnConnect { get; set; }
 
-        public async Task<bool> ConnectAsync(int timeout, bool force = false, ConnectionSource connectionSource = ConnectionSource.Unknown)
+        public async Task<bool> ConnectAsync(
+            int timeout, 
+            bool force = false, 
+            ConnectionSource connectionSource = ConnectionSource.Unknown, 
+            bool requestCapabilities = true)
         {
             if (force || !IsConnected)
             {
@@ -234,7 +238,9 @@ namespace nanoFramework.Tools.Debugger
                 }
             }
 
-            if ((force || Capabilities.IsUnknown) && ConnectionSource == ConnectionSource.nanoCLR)
+            if (ConnectionSource == ConnectionSource.nanoCLR &&
+                requestCapabilities &&
+                (force || Capabilities.IsUnknown) )
             {
                 CancellationTokenSource cancellationTSource = new CancellationTokenSource();
 


### PR DESCRIPTION
## Description
- Add new parameter to chose if device capabilities should be requested.
- Bump version to 1.11.0-preview.

## Motivation and Context
- Needed a lighter method to "just" connect to a target and check if it is a nanoDevice. Previous implementation was always requesting all the device capabilities for nothing.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>