### PR TITLE
Replace several throws with return value

### DIFF
--- a/source/USB Test App WPF/MainWindow.xaml.cs
+++ b/source/USB Test App WPF/MainWindow.xaml.cs
@@ -194,42 +194,28 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 
             await Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() =>
             {
-
                  try
                  {
-                     var deviceState = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.GetExecutionMode();
-
-                     if (deviceState == Commands.DebuggingExecutionChangeConditions.State.Unknown)
-                     {
-                         Debug.WriteLine($">>> Couldn't determine device state <<<<");
-                     }
-                     else if (deviceState == Commands.DebuggingExecutionChangeConditions.State.Initialize)
-                     {
-                         Debug.WriteLine($">>> Device is in initialized state <<<<");
-                     }
-                     else if ((deviceState & Commands.DebuggingExecutionChangeConditions.State.ProgramRunning) == Commands.DebuggingExecutionChangeConditions.State.ProgramRunning)
-                     {
-                         if ((deviceState & Commands.DebuggingExecutionChangeConditions.State.Stopped) == Commands.DebuggingExecutionChangeConditions.State.Stopped)
-                         {
-                             Debug.WriteLine($">>> Device is running a program **BUT** execution is stopped <<<<");
-                         }
-                         else
-                         {
-                             Debug.WriteLine($">>> Device is running a program <<<<");
-                         }
-                     }
-                     else if ((deviceState & Commands.DebuggingExecutionChangeConditions.State.ProgramExited) == Commands.DebuggingExecutionChangeConditions.State.ProgramExited)
-                     {
-                         if ((deviceState & Commands.DebuggingExecutionChangeConditions.State.ResolutionFailed) == Commands.DebuggingExecutionChangeConditions.State.ResolutionFailed)
-                         {
-                             Debug.WriteLine($">>> Device can't start execution because type resolution has failed <<<<");
-                         }
-                         else
-                         {
-                             Debug.WriteLine($">>> Device it's idle after exiting from a program execution <<<<");
-                         }
-                     }
-
+                    if ((DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.IsDeviceInInitializeState())
+                    {
+                        Debug.WriteLine($">>> Device is in initialized state <<<<");
+                    }
+                    else if ((DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.IsDeviceInProgramRunningState())
+                    {
+                        Debug.WriteLine($">>> Device is running a program <<<<");
+                    }
+                    else if ((DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.IsDeviceInExitedState())
+                    {
+                        Debug.WriteLine($">>> Device it's idle after exiting from a program execution <<<<");
+                    }
+                    else if ((DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.IsDeviceStoppedOnTypeResolutionFailed())
+                    {
+                        Debug.WriteLine($">>> Device can't start execution because type resolution has failed <<<<");
+                    }
+                    else
+                    {
+                        Debug.WriteLine($">>> Couldn't determine device state <<<<");
+                    }
                  }
                  catch
                  {

--- a/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
@@ -75,6 +75,7 @@ For UWP look for the respective Nuget package.</PackageReleaseNotes>
   <ItemGroup>
     <None Include="app.config" />
     <None Include="key.snk" />
+    <None Include="packages.lock.json" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fody">
@@ -86,7 +87,7 @@ For UWP look for the respective Nuget package.</PackageReleaseNotes>
       <Version>10.0.18362.2005</Version>
     </PackageReference>
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.0.50</Version>
+      <Version>3.1.68</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -94,7 +95,7 @@ For UWP look for the respective Nuget package.</PackageReleaseNotes>
       <Version>2.6.1</Version>
     </PackageReference>
     <PackageReference Include="System.Threading.Tasks.Extensions">
-      <Version>4.5.2</Version>
+      <Version>4.5.3</Version>
     </PackageReference>
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>

--- a/source/nanoFramework.Tools.DebugLibrary.Net/packages.lock.json
+++ b/source/nanoFramework.Tools.DebugLibrary.Net/packages.lock.json
@@ -20,9 +20,9 @@
       },
       "Nerdbank.GitVersioning": {
         "type": "Direct",
-        "requested": "[3.0.50, )",
-        "resolved": "3.0.50",
-        "contentHash": "jDbjKVHHhLBRjvRw+nDs8d/g8hRt7YUb1LHKEt3cR52SpnZfxf5Q7NGNxmnmeYxoT8ecAW44P4wciXz3yPlubA=="
+        "requested": "[3.1.68, )",
+        "resolved": "3.1.68",
+        "contentHash": "34pkY22UQQ/69bBFSl+PoQPuY2+ILbIFOWsqTdIU/AuvSH19aCvdHsT6WX0hcRZL2VNZeCiHkuhcY8bSjn4ifQ=="
       },
       "PropertyChanged.Fody": {
         "type": "Direct",
@@ -35,9 +35,9 @@
       },
       "System.Threading.Tasks.Extensions": {
         "type": "Direct",
-        "requested": "[4.5.2, )",
-        "resolved": "4.5.2",
-        "contentHash": "BG/TNxDFv0svAzx8OiMXDlsHfGw623BZ8tCXw4YLhDFDvDhNUEV58jKYMGRnkbJNm7c3JNNJDiN7JBMzxRBR2w==",
+        "requested": "[4.5.3, )",
+        "resolved": "4.5.3",
+        "contentHash": "+MvhNtcvIbqmhANyKu91jQnvIRVSTiaOiFNfKWwXGHG48YAb4I/TyH8spsySiPYla7gKal5ZnF3teJqZAximyQ==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "4.5.2"
         }

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -383,7 +383,7 @@ namespace nanoFramework.Tools.Debugger
             set { }
         }
 
-        public bool ThrowOnCommunicationFailure { get; set; }
+        public bool ThrowOnCommunicationFailure { get; set; } = false;
 
         #region Events 
 
@@ -1122,16 +1122,17 @@ namespace nanoFramework.Tools.Debugger
         {
             using (CancellationTokenSource cts = new CancellationTokenSource())
             {
+                WireProtocolRequest request = new WireProtocolRequest(message, cts.Token);
+
                 //Checking whether IsRunning and adding the request to m_requests
                 //needs to be atomic to avoid adding a request after the Engine
                 //has been stopped.
 
                 if (!IsRunning)
                 {
-                    throw new ApplicationException("Engine is not running or process has exited.");
+                    return request;
                 }
 
-                WireProtocolRequest request = new WireProtocolRequest(message, cts.Token);
                 _requestsStore.Add(request);
 
                 try

--- a/source/version.json
+++ b/source/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.15.0-preview.{height}",
+  "version": "1.16.0-preview.{height}",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
## Description
- Set default value for Engine.ThrowOnCommunicationFailure to false.
- Update several NuGets.
- Rework test app regarding device execution querying.
- Bump version to 1.16.0-preview.

## Motivation and Context
- Throwing so many exception was putting a high burden on the callers to trap and deal with those, thus having the potential to cause VS to freeze and exit without warning.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
