### PR TITLE
Improve commands that use full WP buffer capacity

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
@@ -498,7 +498,9 @@ namespace nanoFramework.Tools.Debugger
                             return new Tuple<uint, bool>(0, false);
                         }
 
-                        uint buflen = len > DebugEngine.WireProtocolPacketSize ? DebugEngine.WireProtocolPacketSize : (uint)len;
+                        // get packet length, either the maximum allowed size or whatever is still available to TX
+                        uint buflen = Math.Min((uint)DebugEngine.GetPacketMaxLength(new Commands.Monitor_WriteMemory()), (uint)len);
+
                         byte[] data = new byte[buflen];
 
                         if (block.data.Read(data, 0, (int)buflen) <= 0)

--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -1304,7 +1304,7 @@ namespace nanoFramework.Tools.Debugger
                 Commands.Monitor_WriteMemory cmd = new Commands.Monitor_WriteMemory();
 
                 // get packet length, either the maximum allowed size or whatever is still available to TX
-                int packetLength = Math.Min((int)WireProtocolPacketSize, count);
+                int packetLength = Math.Min(GetPacketMaxLength(cmd), count);
 
                 cmd.PrepareForSend(address, buf, position, packetLength);
 
@@ -3587,11 +3587,11 @@ namespace nanoFramework.Tools.Debugger
                     };
 
                     // get packet length, either the maximum allowed size or whatever is still available to TX
-                    int packetLength = Math.Min((int)WireProtocolPacketSize, count);
+                    int packetLength = Math.Min(GetPacketMaxLength(cmd), count);
 
                     // check if this is the last chunk
                     if(count <= packetLength &&
-                       packetLength <= WireProtocolPacketSize)
+                       packetLength <= GetPacketMaxLength(cmd))
                     {
                         // yes, signal that by setting the Done field
                         cmd.Done = 1;
@@ -3646,6 +3646,11 @@ namespace nanoFramework.Tools.Debugger
 
             // default to false
             return false;
+        }
+
+        public int GetPacketMaxLength(Commands.OverheadBase cmd)
+        {
+            return (int)WireProtocolPacketSize - cmd.Overhead;
         }
 
         /// <summary>
@@ -3744,7 +3749,7 @@ namespace nanoFramework.Tools.Debugger
                     };
 
                     // get packet length, either the maximum allowed size or whatever is still available to TX
-                    int packetLength = Math.Min((int)WireProtocolPacketSize, count);
+                    int packetLength = Math.Min(GetPacketMaxLength(cmd), count);
 
                     cmd.PrepareForSend(configurationSerialized, packetLength, position);
 


### PR DESCRIPTION
## Description
- Add new base class OverheadBase to get overhead of command to be TXed to target.
- All commands that have a buffer now derive from this new class.
- Update processing of all engine commands that use the above commands.

## Motivation and Context
- Commands that use a data buffer were relying on packet length to adjust the chunk size. This is wrong because that doesn't take into account the overhead of the rest of the command thus overflowing the buffer on the target.
Now the data buffer is adjusted so that the payload doesn't exceed the wire protocol packet size.

## How Has This Been Tested?<!-- (if applicable) -->
- WPF test app.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
