### PR TITLE
Add short timeout to reboot request

### DIFF
--- a/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/source/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -1454,17 +1454,20 @@ namespace nanoFramework.Tools.Debugger
             {
                 _pingEvent.Reset();
 
-                IncomingMessage reply = PerformSyncRequest(Commands.c_Monitor_Reboot, Flags.c_NoCaching, cmd);
+                // don't keep hopes too high on a reply from reboot request, so make it with a very short timeout
+                IncomingMessage reply = PerformSyncRequest(Commands.c_Monitor_Reboot, Flags.c_NoCaching, cmd, 500);
 
-                // if reboot options end on a hard reboot, force connection state to disconnected
+                // if reboot options ends on a hard reboot, force connection state to disconnected
                 if (((RebootOptions)cmd.flags == RebootOptions.EnterBootloader) ||
                     ((RebootOptions)cmd.flags == RebootOptions.NormalReboot))
                 {
                     IsConnected = false;
                 }
-
-                // wait for ping after reboot
-                _pingEvent.WaitOne(10000);
+                else
+                {
+                    // wait for ping after reboot
+                    var eventOcurred = _pingEvent.WaitOne(10000);
+                }
             }
             finally
             {


### PR DESCRIPTION
## Description
- For reboot requests that cause hard reboot on the targets it's very likely that the reply back is not sent. Issuing the command with a very short timeout speeds up things.
- Add else to wait for ping event to occur on soft reboot.

## Motivation and Context
- Improve behaviour and execution of reboot command.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
