### PR TITLE
Work on capability flags

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/CLRCapabilities.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/CLRCapabilities.cs
@@ -40,22 +40,18 @@ namespace nanoFramework.Tools.Debugger
             /// <summary>
             /// This flag indicates that the device requires em erase command before updating the configuration block.
             /// </summary>
+            /// <remarks>
+            /// *********************************************************************
+            /// ** THIS FLAG IS DEPRECATED AND WILL BE REMOVED IN A FUTURE VERSION **
+            /// ** USE Monitor_Ping_c_ConfigBlockRequiresErase INSTEAD             **
+            /// *********************************************************************
+            /// </remarks>
             ConfigBlockRequiresErase =  0x00000800,
 
             /// <summary>
             /// This flag indicates that the device has nanoBooter.
             /// </summary>
             HasNanoBooter =             0x00001000,
-
-            /// <summary>
-            /// This flag indicates that the device has a proprietary bootloader.
-            /// </summary>
-            HasProprietaryBooter =      0x00002000,
-
-            /// <summary>
-            /// This flag indicates that the target device is IFU capable.
-            /// </summary>
-            IFUCapable =                0x00004000,
 
             /// <summary>
             /// These bits are generic and are meant to be used to store platform specific capabilities.

--- a/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
@@ -147,7 +147,7 @@ namespace nanoFramework.Tools.Debugger
                 // there is a reply, so the device _has_ to be connected
                 DebugEngine.IsConnected = true;
 
-                switch (reply.m_source)
+                switch (reply.Source)
                 {
                     case Commands.Monitor_Ping.c_Ping_Source_NanoCLR:
                         return PingConnectionType.nanoCLR;
@@ -214,7 +214,7 @@ namespace nanoFramework.Tools.Debugger
                     {
                         Commands.Monitor_Ping.Reply reply = DebugEngine.GetConnectionSource();
 
-                        ret = (reply.m_source == Commands.Monitor_Ping.c_Ping_Source_NanoBooter);
+                        ret = (reply.Source == Commands.Monitor_Ping.c_Ping_Source_NanoBooter);
 
                         break;
                     }
@@ -279,7 +279,7 @@ namespace nanoFramework.Tools.Debugger
             long total = 0;
             long value = 0;
 
-            bool isConnectedToCLR = ((ping != null) && (ping.m_source == Commands.Monitor_Ping.c_Ping_Source_NanoCLR));
+            bool isConnectedToCLR = ((ping != null) && (ping.Source == Commands.Monitor_Ping.c_Ping_Source_NanoCLR));
 
 
             if (isConnectedToCLR)
@@ -616,7 +616,7 @@ namespace nanoFramework.Tools.Debugger
             }
 
             // only execute if we are talking to the nanoBooter, otherwise reboot
-            if (reply.m_source == Commands.Monitor_Ping.c_Ping_Source_NanoBooter)
+            if (reply.Source == Commands.Monitor_Ping.c_Ping_Source_NanoBooter)
             {
                 return DebugEngine.ExecuteMemory(entryPoint);
             }

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -116,33 +116,56 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
         public class Monitor_Ping
         {
-            public const uint c_Ping_Source_NanoCLR =       0x00010000;
-            public const uint c_Ping_Source_NanoBooter =    0x00010001;
-            public const uint c_Ping_Source_Host =          0x00010002;
+            ///////////////////////////////////////////////////////////////////////
+            
+            public const uint c_Ping_Source_NanoCLR =                   0x00010000;
+            public const uint c_Ping_Source_NanoBooter =                0x00010001;
+            public const uint c_Ping_Source_Host =                      0x00010002;
 
-            public const uint c_Ping_DbgFlag_Stop = 0x00000001;
-            public const uint c_Ping_DbgFlag_BigEndian = 0x02000002;
-            public const uint c_Ping_DbgFlag_AppExit = 0x00000004;
+            public const uint c_Ping_DbgFlag_Stop =                     0x00000001;
+            public const uint c_Ping_DbgFlag_BigEndian =                0x02000002;
+            public const uint c_Ping_DbgFlag_AppExit =                  0x00000004;
 
+            ///////////////////////////////////////////////////////////////////////
             // flags specific to Wire Protocol capabilities
-            public const uint c_Ping_WPFlag_SupportsCRC32 = 0x00000010;
+            public const uint c_Ping_WPFlag_SupportsCRC32 =             0x00000010;
 
             // Wire Protocol packet size (3rd position)
-            public const uint Monitor_Ping_c_PacketSize_Position = 0x00000F00;
+            public const uint Monitor_Ping_c_PacketSize_Position =      0x00000F00;
             // default packet size is 1024
-            public const uint Monitor_Ping_c_PacketSize_1024 = 0x00000100;
-            public const uint Monitor_Ping_c_PacketSize_0512 = 0x00000200;
-            public const uint Monitor_Ping_c_PacketSize_0256 = 0x00000300;
-            public const uint Monitor_Ping_c_PacketSize_0128 = 0x00000400;
+            public const uint Monitor_Ping_c_PacketSize_1024 =          0x00000100;
+            public const uint Monitor_Ping_c_PacketSize_0512 =          0x00000200;
+            public const uint Monitor_Ping_c_PacketSize_0256 =          0x00000300;
+            public const uint Monitor_Ping_c_PacketSize_0128 =          0x00000400;
 
-            public uint m_source;
-            public uint m_dbg_flags;
+            //////////////////////////////////////////////////////////////////////
+            // flags related with device capabilities
+
+            /// <summary>
+            /// This flag indicates that the device has a proprietary bootloader.
+            /// </summary>
+            public const uint Monitor_Ping_c_HasProprietaryBooter =     0x00010000;
+
+            /// <summary>
+            /// This flag indicates that the target device is IFU capable.
+            /// </summary>
+            public const uint Monitor_Ping_c_IFUCapable =               0x00020000;
+
+            /// <summary>
+            /// This flag indicates that the device requires that the configuration block to be erased before updating it.
+            /// </summary>
+            public const uint Monitor_Ping_c_ConfigBlockRequiresErase = 0x00040000;
+
+            ///////////////////////////////////////////////////////////////////////
+
+            public uint Source;
+            public uint Flags;
 
 
             public class Reply
             {
-                public uint m_source;
-                public uint m_dbg_flags;
+                public uint Source;
+                public uint Flags;
             }
         }
 

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -175,8 +175,8 @@ namespace nanoFramework.Tools.Debugger
 
                     Commands.Monitor_Ping cmd = new Commands.Monitor_Ping
                     {
-                        m_source = Commands.Monitor_Ping.c_Ping_Source_Host,
-                        m_dbg_flags = (StopDebuggerOnConnect ? Commands.Monitor_Ping.c_Ping_DbgFlag_Stop : 0)
+                        Source = Commands.Monitor_Ping.c_Ping_Source_Host,
+                        Flags = (StopDebuggerOnConnect ? Commands.Monitor_Ping.c_Ping_DbgFlag_Stop : 0)
                     };
 
                     IncomingMessage msg = PerformSyncRequest(Commands.c_Monitor_Ping, Flags.c_NoCaching, cmd, timeout);
@@ -193,12 +193,12 @@ namespace nanoFramework.Tools.Debugger
 
                     if (msg.Payload is Commands.Monitor_Ping.Reply reply)
                     {
-                        IsTargetBigEndian = (reply.m_dbg_flags & Commands.Monitor_Ping.c_Ping_DbgFlag_BigEndian).Equals(Commands.Monitor_Ping.c_Ping_DbgFlag_BigEndian);
+                        IsTargetBigEndian = (reply.Flags & Commands.Monitor_Ping.c_Ping_DbgFlag_BigEndian).Equals(Commands.Monitor_Ping.c_Ping_DbgFlag_BigEndian);
 
-                        IsCRC32EnabledForWireProtocol = (reply.m_dbg_flags & Commands.Monitor_Ping.c_Ping_WPFlag_SupportsCRC32).Equals(Commands.Monitor_Ping.c_Ping_WPFlag_SupportsCRC32);
+                        IsCRC32EnabledForWireProtocol = (reply.Flags & Commands.Monitor_Ping.c_Ping_WPFlag_SupportsCRC32).Equals(Commands.Monitor_Ping.c_Ping_WPFlag_SupportsCRC32);
 
                         // get Wire Protocol packet size
-                        switch (reply.m_dbg_flags & Commands.Monitor_Ping.Monitor_Ping_c_PacketSize_Position)
+                        switch (reply.Flags & Commands.Monitor_Ping.Monitor_Ping_c_PacketSize_Position)
                         {
                             case Commands.Monitor_Ping.Monitor_Ping_c_PacketSize_0128:
                                 WireProtocolPacketSize = 128;
@@ -222,7 +222,7 @@ namespace nanoFramework.Tools.Debugger
                         // update flag
                         IsConnected = true;
 
-                        ConnectionSource = (reply == null || reply.m_source == Commands.Monitor_Ping.c_Ping_Source_NanoCLR) ? ConnectionSource.nanoCLR : ConnectionSource.nanoBooter;
+                        ConnectionSource = (reply == null || reply.Source == Commands.Monitor_Ping.c_Ping_Source_NanoCLR) ? ConnectionSource.nanoCLR : ConnectionSource.nanoBooter;
 
                         if (m_silent)
                         {
@@ -285,8 +285,8 @@ namespace nanoFramework.Tools.Debugger
             {
                 Commands.Monitor_Ping cmd = new Commands.Monitor_Ping
                 {
-                    m_source = Commands.Monitor_Ping.c_Ping_Source_Host,
-                    m_dbg_flags = (StopDebuggerOnConnect ? Commands.Monitor_Ping.c_Ping_DbgFlag_Stop : 0)
+                    Source = Commands.Monitor_Ping.c_Ping_Source_Host,
+                    Flags = (StopDebuggerOnConnect ? Commands.Monitor_Ping.c_Ping_DbgFlag_Stop : 0)
                 };
 
                 IncomingMessage msg = PerformSyncRequest(Commands.c_Monitor_Ping, Flags.c_NoCaching, cmd);
@@ -629,8 +629,8 @@ namespace nanoFramework.Tools.Debugger
                         {
                             Commands.Monitor_Ping.Reply cmdReply = new Commands.Monitor_Ping.Reply
                             {
-                                m_source = Commands.Monitor_Ping.c_Ping_Source_Host,
-                                m_dbg_flags = (StopDebuggerOnConnect ? Commands.Monitor_Ping.c_Ping_DbgFlag_Stop : 0)
+                                Source = Commands.Monitor_Ping.c_Ping_Source_Host,
+                                Flags = (StopDebuggerOnConnect ? Commands.Monitor_Ping.c_Ping_DbgFlag_Stop : 0)
                             };
 
                             PerformRequestAsync(new OutgoingMessage(_controlller.GetNextSequenceId(), message, _controlller.CreateConverter(), Flags.c_NonCritical, cmdReply), _backgroundProcessorCancellation.Token).ConfigureAwait(false);


### PR DESCRIPTION
## Description
- Move HasProprietaryBooter and IFUCapable flags to Ping.
- Add ConfigBlockRequiresErase to ping because this information is also required when running booter and it wasn't available there.
- Rename Ping flags field to drop "debug" hit on the name.
- Rename Ping source field to follow code style guidelines.

## Motivation and Context
- These capability flags are needed on both booter and CLR so they need to be moved to a command that is present on both.

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
