### PR TITLE
Add Monitor_TargetInfo command

### DIFF
--- a/USB Test App WPF/MainWindow.xaml
+++ b/USB Test App WPF/MainWindow.xaml
@@ -48,7 +48,7 @@
         <Button Content="Set Device Config" HorizontalAlignment="Left" Margin="378,313,0,0" VerticalAlignment="Top" Width="121" Click="SetDeviceConfigButton_Click" />
         <Button Content="ReScan devices" HorizontalAlignment="Left" Margin="250,157,0,0" VerticalAlignment="Top" Width="98" Click="ReScanDevices_Click" />
         <Button Content="Read Test" HorizontalAlignment="Left" Margin="250,313,0,0" VerticalAlignment="Top" Width="98" Click="ReadTestButton_Click" />
-        <Button Content="OEM Info" HorizontalAlignment="Left" Margin="39,313,0,0" VerticalAlignment="Top" Width="110" Click="OemInfoButton_Click" />
+        <Button Content="Target Info" HorizontalAlignment="Left" Margin="39,313,0,0" VerticalAlignment="Top" Width="110" Click="TargetInfoButton_Click" />
         <Button Content="Reboot to nanoBooter" HorizontalAlignment="Left" Margin="378,157,0,0" VerticalAlignment="Top" Width="121" Click="RebootToNanoBooterButton_Click"/>
         <Button Content="Deploy File" HorizontalAlignment="Left" Margin="162,313,0,0" VerticalAlignment="Top" Width="75" Click="DeployFileTestButton_Click" />
 

--- a/USB Test App WPF/MainWindow.xaml.cs
+++ b/USB Test App WPF/MainWindow.xaml.cs
@@ -125,8 +125,6 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 
                     var di = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].GetDeviceInfo();
 
-                    var clrAddress = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].ClrStartAddress;
-
                     Debug.WriteLine("");
                     Debug.WriteLine("");
                     Debug.WriteLine(di.ToString());
@@ -1105,7 +1103,7 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
             (sender as Button).IsEnabled = true;
         }
 
-        private async void OemInfoButton_Click(object sender, RoutedEventArgs e)
+        private async void TargetInfoButton_Click(object sender, RoutedEventArgs e)
         {
             // disable button
             (sender as Button).IsEnabled = false;
@@ -1116,13 +1114,13 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
                 var device = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex];
 
 
-                var oemInfo = device.DebugEngine.GetMonitorOemInfo();
+                var targetInfo = device.DebugEngine.GetMonitorTargetInfo();
 
-                if (oemInfo != null)
+                if (targetInfo != null)
                 {
                     Debug.WriteLine("");
                     Debug.WriteLine("");
-                    Debug.WriteLine($"{oemInfo.ToString()}");
+                    Debug.WriteLine($"{targetInfo.ToString()}");
                     Debug.WriteLine("");
                     Debug.WriteLine("");
                 }

--- a/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/NanoFrameworkDeviceInfo.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/NanoFrameworkDeviceInfo.cs
@@ -231,10 +231,10 @@ namespace nanoFramework.Tools.Debugger
                     output.AppendLine($"  Platform: {Platform?.ToString()}");
                     output.AppendLine();
                     output.AppendLine($"Firmware build Info:");
-                    output.AppendLine($"  Date:     {ImageBuildDate ?? "unknown"}");
-                    output.AppendLine($"  Type:     {VendorInfo ?? "unknown"}");
-                    output.AppendLine($"  Version:  {SolutionBuildVersion}");
-                    output.AppendLine($"  Compiler: {ImageCompilerInfo ?? "unknown"} v{ImageCompilerVersion?.ToString()}");
+                    output.AppendLine($"  Date:        {ImageBuildDate ?? "unknown"}");
+                    output.AppendLine($"  Type:        {VendorInfo ?? "unknown"}");
+                    output.AppendLine($"  CLR Version: {SolutionBuildVersion}");
+                    output.AppendLine($"  Compiler:    {ImageCompilerInfo ?? "unknown"} v{ImageCompilerVersion?.ToString()}");
                     output.AppendLine();
                     output.AppendLine($"OEM Product codes (vendor, model, SKU): {OEM.ToString()}, {Model.ToString()}, {SKU.ToString()}");
                     output.AppendLine();
@@ -242,6 +242,15 @@ namespace nanoFramework.Tools.Debugger
                     output.AppendLine("  " + ModuleSerialNumber);
                     output.AppendLine("  " + SystemSerialNumber);
                     output.AppendLine();
+                    output.AppendLine("Target capabilities:");
+                    output.AppendLine("  Has nanoBooter: " + (Dbg.HasNanoBooter? "YES" : "NO"));
+                    if (Dbg.TargetInfo != null &&
+                        Dbg.HasNanoBooter)
+                    {
+                        output.AppendLine($"  nanoBooter: v{Dbg.TargetInfo.BooterVersion}");
+                    }
+                    output.AppendLine("  IFU capable: " + (Dbg.IsIFUCapable ? "YES" : "NO"));
+                    output.AppendLine("  Has proprietary bootloader: " + (Dbg.HasProprietaryBooter ? "YES" : "NO"));
 
                     output.AppendLine();
                     output.AppendLine("AppDomains:");

--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPortManager.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPortManager.cs
@@ -557,14 +557,28 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                             {
                                 if (device.DebugEngine.ConnectionSource == ConnectionSource.nanoBooter)
                                 {
-                                    var deviceInfo = device.DebugEngine.GetMonitorOemInfo();
-                                    if (deviceInfo != null)
+                                    // try first with new command
+                                    var targetInfo = device.DebugEngine.GetMonitorTargetInfo();
+                                    if (targetInfo != null)
                                     {
-                                        device.TargetName = deviceInfo.TargetName;
-                                        device.Platform = deviceInfo.PlatformName;
+                                        device.TargetName = targetInfo.TargetName;
+                                        device.Platform = targetInfo.PlatformName;
 
                                         validDevice = true;
                                         break;
+                                    }
+                                    else
+                                    {
+                                        // try again with deprecated command
+                                        var deviceInfo = device.DebugEngine.GetMonitorOemInfo();
+                                        if (deviceInfo != null)
+                                        {
+                                            device.TargetName = deviceInfo.TargetName;
+                                            device.Platform = deviceInfo.PlatformName;
+
+                                            validDevice = true;
+                                            break;
+                                        }
                                     }
                                 }
                                 else

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -58,6 +58,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         public const uint c_Monitor_OemInfo = 0x0000000E;
         public const uint c_Monitor_QueryConfiguration = 0x0000000F;
         public const uint c_Monitor_UpdateConfiguration = 0x00000010;
+        public const uint c_Monitor_TargetInfo = 0x00000020;
 
         public class Monitor_Message : IConverter
         {
@@ -183,6 +184,19 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 public void PrepareForDeserialize(int size, byte[] data, Converter converter)
                 {
                     m_releaseInfo = new ReleaseInfo(data.Length);
+                }
+            }
+        }
+
+        public class Monitor_TargetInfo
+        {
+            public class Reply : IConverter
+            {
+                public TargetInfo TargetInfo;
+
+                public void PrepareForDeserialize(int size, byte[] data, Converter converter)
+                {
+                    TargetInfo = new TargetInfo(data.Length);
                 }
             }
         }
@@ -1810,6 +1824,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 {
                     case c_Monitor_Ping: return new Monitor_Ping.Reply();
                     case c_Monitor_OemInfo: return new Monitor_OemInfo.Reply();
+                    case c_Monitor_TargetInfo: return new Monitor_TargetInfo.Reply();
                     case c_Monitor_ReadMemory: return new Monitor_ReadMemory.Reply();
                     case c_Monitor_WriteMemory: return new Monitor_WriteMemory.Reply();
                     case c_Monitor_CheckMemory: return new Monitor_CheckMemory.Reply();

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -115,7 +115,7 @@ namespace nanoFramework.Tools.Debugger
         }
 
         public CLRCapabilities Capabilities { get; internal set; }
-
+        public TargetInfo TargetInfo { get; private set; }
         public List<Commands.Monitor_FlashSectorMap.FlashSectorData> FlashSectorMap { get; private set; }
 
         public BinaryFormatter CreateBinaryFormatter()
@@ -279,6 +279,9 @@ namespace nanoFramework.Tools.Debugger
                 // fill flash sector map
                 FlashSectorMap = GetFlashSectorMap();
 
+                // get target info
+                TargetInfo = GetMonitorTargetInfo();
+
                 var tempCapabilities = DiscoverCLRCapabilities(cancellationTSource.Token);
 
                 if (tempCapabilities != null && !tempCapabilities.IsUnknown)
@@ -299,6 +302,9 @@ namespace nanoFramework.Tools.Debugger
             if (ConnectionSource == ConnectionSource.nanoBooter &&
                 requestCapabilities && force)
             {
+                // get target info
+                TargetInfo = GetMonitorTargetInfo();
+
                 // fill flash sector map
                 FlashSectorMap = GetFlashSectorMap();
             }
@@ -1269,6 +1275,25 @@ namespace nanoFramework.Tools.Debugger
                     Commands.Monitor_OemInfo.Reply cmdReply = reply.Payload as Commands.Monitor_OemInfo.Reply;
 
                     return cmdReply.m_releaseInfo;
+                }
+            }
+
+            return null;
+        }
+
+        public TargetInfo GetMonitorTargetInfo()
+        {
+            Commands.Monitor_TargetInfo cmd = new Commands.Monitor_TargetInfo();
+
+            IncomingMessage reply = PerformSyncRequest(Commands.c_Monitor_TargetInfo, 0, cmd);
+
+            if (reply != null)
+            {
+                if (reply.Payload is Commands.Monitor_TargetInfo.Reply)
+                {
+                    Commands.Monitor_TargetInfo.Reply cmdReply = reply.Payload as Commands.Monitor_TargetInfo.Reply;
+
+                    return cmdReply.TargetInfo;
                 }
             }
 

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/TargetInfo.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/TargetInfo.cs
@@ -1,0 +1,128 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Text;
+
+namespace nanoFramework.Tools.Debugger.WireProtocol
+{
+    public class TargetInfo : IConverter
+    {
+        private const int c_sizeOfVersion = 8;
+        private const int c_sizeOfInfo = 128;
+        private const int c_sizeOfTargetName = 32;
+        private const int c_sizeOfPlatformName = 32;
+        private const int c_sizeOfPlatformInfo = 128;
+
+        // these constants below hold the size of the current version 
+        // they are used to init the byte array with raw data and trying to check if there is enough data for PlatformInfo
+        private const int TotalSizeOfRaw = c_sizeOfVersion + c_sizeOfVersion + c_sizeOfInfo + c_sizeOfTargetName + c_sizeOfPlatformName + c_sizeOfPlatformInfo;
+
+        private readonly VersionStruct _booterVersion;
+        private readonly VersionStruct _clrVersion;
+        private byte[] _rawInfo;
+
+        public TargetInfo(int dataLength = TotalSizeOfRaw)
+        {
+            _booterVersion = new VersionStruct();
+            _clrVersion = new VersionStruct();
+
+            InitFields(dataLength);
+        }
+
+        private void InitFields(int dataLength)
+        {
+            if (dataLength == TotalSizeOfRaw)
+            {
+                // need to subtract the size of both version fields
+                _rawInfo = new byte[TotalSizeOfRaw - c_sizeOfVersion - c_sizeOfVersion];
+            }
+            else
+            {
+                // shouldn't be here
+                throw new ArgumentOutOfRangeException($"{nameof(dataLength)} has an invalid value");
+            }
+        }
+
+        public void PrepareForDeserialize(int size, byte[] data, Converter converter)
+        {
+            // need to subtract the size of both version fields
+            _rawInfo =  new byte[data.Length - c_sizeOfVersion - c_sizeOfVersion];
+        }
+
+        public Version BooterVersion => _booterVersion.Version;
+
+        public Version ClrVersion => _clrVersion.Version;
+
+        public string Info
+        {
+            get
+            {
+                var myString = Encoding.UTF8.GetString(_rawInfo, 0, c_sizeOfInfo);
+                return myString.Substring(0, myString.IndexOf('\0'));
+            }
+        }
+
+        public string TargetName
+        {
+            get
+            {
+                var myString = Encoding.UTF8.GetString(_rawInfo, c_sizeOfInfo, c_sizeOfTargetName);
+                return myString.Substring(0, myString.IndexOf('\0'));
+            }
+        }
+
+        public string PlatformName
+        {
+            get
+            {
+                var myString = Encoding.UTF8.GetString(_rawInfo, c_sizeOfInfo + c_sizeOfTargetName, c_sizeOfPlatformName);
+                return myString.Substring(0, myString.IndexOf('\0'));
+            }
+        }
+
+        public string PlatformInfo
+        {
+            get
+            {
+                if (_rawInfo.Length == TotalSizeOfRaw - c_sizeOfVersion - c_sizeOfVersion)
+                {
+                    var myString = Encoding.UTF8.GetString(_rawInfo, c_sizeOfInfo + c_sizeOfTargetName + c_sizeOfPlatformName, c_sizeOfPlatformInfo);
+                    return myString.Substring(0, myString.IndexOf('\0'));
+                }
+                else
+                {
+                    // old version format, no PlatformInfo
+                    return "";
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            try
+            {
+                StringBuilder output = new StringBuilder();
+
+                output.AppendLine($"HAL build info: {Info?.ToString()}");
+                output.AppendLine($"  Target:     {TargetName?.ToString()}");
+                output.AppendLine($"  Platform:   {PlatformName?.ToString()}");
+                output.AppendLine($"  nanoBooter: v{BooterVersion}");
+                output.AppendLine($"  nanoCLR:    v{ClrVersion}");
+                output.AppendLine($"  Type:       {PlatformInfo}");
+                output.AppendLine();
+
+                return output.ToString();
+            }
+            catch
+            {
+                // OK to fail. Most likely because of a formatting issue.
+            }
+
+            return "ReleaseInfo is not valid!";
+        }
+    }
+}

--- a/nanoFramework.Tools.DebugLibrary.Shared/nanoFramework.Tools.DebugLibrary.Net.projitems
+++ b/nanoFramework.Tools.DebugLibrary.Shared/nanoFramework.Tools.DebugLibrary.Net.projitems
@@ -122,6 +122,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)WireProtocol\PingConnectionType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WireProtocol\PortFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WireProtocol\RebootOptions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WireProtocol\TargetInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WireProtocol\ReleaseInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WireProtocol\WireProtocolRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WireProtocol\StringEventArgs.cs" />


### PR DESCRIPTION
## Description
- Expose BooterVersion anc ClrVersion as Version type properties in NanoDeviceBase.
- Deployment and CLR start address are now methods.
- Improve code in RebootTonanoBooter to become more robust to exceptions.
- Improve code in PrepareForDeployAsync to use more direct properties.
- Update code to use new command Monitor_TargetInfo.
- Improve code to make use of new exposed properties in NanoDevice.
- ConnectAsync in debugger engine now retrieves target capabilites and exposes those in a property.
- ConnectAsync in debugger engine now retrieves flash map.
- Improve ToString output of device capabilites to include new properties.

## Motivation and Context
- Adds support for nanoframework/nf-interpreter#1789.
- Makes target properties more readily available.

## How Has This Been Tested?<!-- (if applicable) -->
- Test apps.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
