### PR TITLE
Improve device detection

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPortManager.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPortManager.cs
@@ -550,10 +550,9 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                             OnLogMessageAvailable(NanoDevicesEventSource.Log.CheckingValidDevice($" {device.Device.DeviceInformation.DeviceInformation.Id} @ { baudRate }"));
 
                             if (await device.DebugEngine.ConnectAsync(
-                                1000,
+                                2000,
                                 true,
-                                ConnectionSource.Unknown,
-                                false))
+                                ConnectionSource.Unknown))
                             {
                                 if (device.DebugEngine.ConnectionSource == ConnectionSource.nanoBooter)
                                 {

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -300,7 +300,8 @@ namespace nanoFramework.Tools.Debugger
             }
 
             if (ConnectionSource == ConnectionSource.nanoBooter &&
-                requestCapabilities && force)
+                requestCapabilities && 
+                (force || TargetInfo == null))
             {
                 // get target info
                 TargetInfo = GetMonitorTargetInfo();


### PR DESCRIPTION
## Description
- Increase timeout of valid nanoDevice call.
- Remove request capabilites parameter in ConnectAsync. Default is already true.
- Fix condition to get target information and flash sector map on nanoBooter connect.

## Motivation and Context
- Target details weren't being retrieved on nanoBooter connect operation.
- Target detection was missing some "slow" devices because of the too short timeout.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
