### PR TITLE
Fix output of address on erase operation

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
@@ -487,14 +487,16 @@ namespace nanoFramework.Tools.Debugger
                 for (int block = 0; block < flashSectorData.m_NumBlocks; block++)
                 {
                     progress?.Report($"Erasing sector @ 0x{flashSectorData.m_StartAddress:X8}...");
-                    
+
+                    var sectorAddress = (uint)(flashSectorData.m_StartAddress + block * flashSectorData.m_BytesPerBlock);
+
                     (AccessMemoryErrorCodes ErrorCode, bool Success) = DebugEngine.EraseMemory(
-                        (uint)(flashSectorData.m_StartAddress + block * flashSectorData.m_BytesPerBlock),
+                        sectorAddress,
                         flashSectorData.m_BytesPerBlock);
 
                     if (!Success)
                     {
-                        progress?.Report($"Error erasing sector @ 0x{flashSectorData.m_StartAddress:X8}.");
+                        progress?.Report($"Error erasing sector @ 0x{sectorAddress:X8}.");
 
                         return false;
                     }
@@ -503,7 +505,7 @@ namespace nanoFramework.Tools.Debugger
                     if (ErrorCode != AccessMemoryErrorCodes.NoError)
                     {
                         // operation failed
-                        progress?.Report($"Error erasing sector @ 0x{flashSectorData.m_StartAddress:X8}. Error code: {ErrorCode}.");
+                        progress?.Report($"Error erasing sector @ 0x{sectorAddress:X8}. Error code: {ErrorCode}.");
 
                         // don't bother continuing
                         return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Made address variable common to use on request and output.

## Motivation and Context
- Fixes wrong output with flash sector being erased.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
