### PR TITLE
Work on async calls

### DIFF
--- a/Serial Test App UWP/MainPage.xaml.cs
+++ b/Serial Test App UWP/MainPage.xaml.cs
@@ -48,11 +48,11 @@ namespace Test_App_UWP
             
         }
 
-        private async void button1_Click(object sender, RoutedEventArgs e)
+        private void button1_Click(object sender, RoutedEventArgs e)
         {
-            var s = await App.NanoFrameworkSerialDebugClient.NanoFrameworkDevices[0].DebugEngine.SendBufferAsync(new byte[] { (byte)'x', (byte)'x' }, TimeSpan.FromMilliseconds(1000), new CancellationToken());
+            var s = App.NanoFrameworkSerialDebugClient.NanoFrameworkDevices[0].DebugEngine.SendBuffer(new byte[] { (byte)'x', (byte)'x' }, TimeSpan.FromMilliseconds(1000), new CancellationToken());
 
-            var r = await App.NanoFrameworkSerialDebugClient.NanoFrameworkDevices[0].DebugEngine.ReadBufferAsync(10, TimeSpan.FromMilliseconds(1000), new CancellationToken());
+            var r = App.NanoFrameworkSerialDebugClient.NanoFrameworkDevices[0].DebugEngine.ReadBuffer(10, TimeSpan.FromMilliseconds(1000), new CancellationToken());
         }
 
         private void pingButton_Click(object sender, RoutedEventArgs e)

--- a/USB Test App UWP/MainPage.xaml.cs
+++ b/USB Test App UWP/MainPage.xaml.cs
@@ -46,11 +46,11 @@ namespace Test_App_UWP
             
         }
 
-        private async void button1_Click(object sender, RoutedEventArgs e)
+        private void button1_Click(object sender, RoutedEventArgs e)
         {
-            var s = await App.NanoFrameworkUsbDebugClient.NanoFrameworkDevices[0].DebugEngine.SendBufferAsync(new byte[] { (byte)'x', (byte)'x' }, TimeSpan.FromMilliseconds(1000), new CancellationToken());
+            var s = App.NanoFrameworkUsbDebugClient.NanoFrameworkDevices[0].DebugEngine.SendBuffer(new byte[] { (byte)'x', (byte)'x' }, TimeSpan.FromMilliseconds(1000), new CancellationToken());
 
-            var r = await App.NanoFrameworkUsbDebugClient.NanoFrameworkDevices[0].DebugEngine.ReadBufferAsync(10, TimeSpan.FromMilliseconds(1000), new CancellationToken());
+            var r = App.NanoFrameworkUsbDebugClient.NanoFrameworkDevices[0].DebugEngine.ReadBuffer(10, TimeSpan.FromMilliseconds(1000), new CancellationToken());
         }
 
         private void pingButton_Click(object sender, RoutedEventArgs e)

--- a/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDevice.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDevice.cs
@@ -80,11 +80,11 @@ namespace nanoFramework.Tools.Debugger
         {
             if (Device is NanoUsbDevice)
             {
-                return await ConnectionPort.ConnectDeviceAsync();
+                return await ConnectionPort.ConnectDevice();
             }
             else if (Device is NanoSerialDevice)
             {
-                return await ConnectionPort.ConnectDeviceAsync();
+                return await ConnectionPort.ConnectDevice();
             }
 
             return false;

--- a/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
@@ -282,7 +282,10 @@ namespace nanoFramework.Tools.Debugger
         {
             bool ret = false;
 
-            if (!await DebugEngine.ConnectAsync(1000, true)) return false;
+            if (!await DebugEngine.ConnectAsync(1000, true))
+            {
+                return false;
+            }
 
             if (DebugEngine != null)
             {
@@ -537,7 +540,10 @@ namespace nanoFramework.Tools.Debugger
         {
             if (DebugEngine.ConnectionSource == ConnectionSource.nanoCLR)
             {
-                if (await DeployMFUpdateAsync(comprFilePath, cancellationToken, progress)) return true;
+                if (await DeployMFUpdateAsync(comprFilePath, cancellationToken, progress))
+                {
+                    return true;
+                }
             }
 
             return false;
@@ -741,7 +747,7 @@ namespace nanoFramework.Tools.Debugger
 
                         try
                         {
-                            await DebugEngine.SendBufferAsync(Encoding.UTF8.GetBytes(execRec), TimeSpan.FromMilliseconds(1000), cancellationToken);
+                            DebugEngine.SendBuffer(Encoding.UTF8.GetBytes(execRec), TimeSpan.FromMilliseconds(1000), cancellationToken);
 
                             // check if cancellation was requested 
                             if (cancellationToken.IsCancellationRequested)
@@ -749,7 +755,7 @@ namespace nanoFramework.Tools.Debugger
                                 return false;
                             }
 
-                            await DebugEngine.SendBufferAsync(Encoding.UTF8.GetBytes("\n"), TimeSpan.FromMilliseconds(1000), cancellationToken);
+                            DebugEngine.SendBuffer(Encoding.UTF8.GetBytes("\n"), TimeSpan.FromMilliseconds(1000), cancellationToken);
                         }
                         catch
                         {
@@ -810,7 +816,7 @@ namespace nanoFramework.Tools.Debugger
                 {
                     if (cancellationToken.IsCancellationRequested) return false;
 
-                    await DebugEngine.SendBufferAsync(Encoding.UTF8.GetBytes("xx\n"), TimeSpan.FromMilliseconds(5000), cancellationToken);
+                    DebugEngine.SendBuffer(Encoding.UTF8.GetBytes("xx\n"), TimeSpan.FromMilliseconds(5000), cancellationToken);
 
                     if (m_evtMicroBooterError.WaitOne(100))
                     {
@@ -1069,11 +1075,11 @@ namespace nanoFramework.Tools.Debugger
                                 continue;
                             }
 
-                            await DebugEngine.SendBufferAsync(Encoding.UTF8.GetBytes("\n"), TimeSpan.FromMilliseconds(1000), cancellationToken);
+                            DebugEngine.SendBuffer(Encoding.UTF8.GetBytes("\n"), TimeSpan.FromMilliseconds(1000), cancellationToken);
 
-                            await DebugEngine.SendBufferAsync(Encoding.UTF8.GetBytes(parsedFile.Records[key]), TimeSpan.FromMilliseconds(20000), cancellationToken);
+                            DebugEngine.SendBuffer(Encoding.UTF8.GetBytes(parsedFile.Records[key]), TimeSpan.FromMilliseconds(20000), cancellationToken);
 
-                            await DebugEngine.SendBufferAsync(Encoding.UTF8.GetBytes("\n"), TimeSpan.FromMilliseconds(1000), cancellationToken);
+                            DebugEngine.SendBuffer(Encoding.UTF8.GetBytes("\n"), TimeSpan.FromMilliseconds(1000), cancellationToken);
 
                             if (pipe-- <= 0)
                             {

--- a/nanoFramework.Tools.DebugLibrary.Shared/PortDefinitions/IPort.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortDefinitions/IPort.cs
@@ -11,11 +11,11 @@ namespace nanoFramework.Tools.Debugger
 {
     public interface IPort
     {
-        Task<uint> SendBufferAsync(byte[] buffer, TimeSpan waiTimeout, CancellationToken cancellationToken);
+        uint SendBuffer(byte[] buffer, TimeSpan waiTimeout, CancellationToken cancellationToken);
 
-        Task<byte[]> ReadBufferAsync(uint bytesToRead, TimeSpan waiTimeout, CancellationToken cancellationToken);
+        byte[] ReadBuffer(uint bytesToRead, TimeSpan waiTimeout, CancellationToken cancellationToken);
 
-        Task<bool> ConnectDeviceAsync();
+        Task<bool> ConnectDevice();
 
         void DisconnectDevice();
     }

--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPortManager.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPortManager.cs
@@ -316,10 +316,10 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                     newNanoFrameworkDevice.ConnectionPort = new SerialPort(this, newNanoFrameworkDevice);
                     newNanoFrameworkDevice.Transport = TransportType.Serial;
 
-                    if (await newNanoFrameworkDevice.ConnectionPort.ConnectDeviceAsync())
-                    {
-                        await Task.Yield();
+                    await Task.Delay(100);
 
+                    if (await newNanoFrameworkDevice.ConnectionPort.ConnectDevice())
+                    {
                         if (await CheckValidNanoFrameworkSerialDeviceAsync(newNanoFrameworkDevice))
                         {
                             //add device to the collection
@@ -350,9 +350,8 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
                             OnLogMessageAvailable(NanoDevicesEventSource.Log.CheckingValidDevice($" {newNanoFrameworkDevice.Device.DeviceInformation.DeviceInformation.Id} *** 2nd attempt ***"));
 
-                            if (await newNanoFrameworkDevice.ConnectionPort.ConnectDeviceAsync())
+                            if (await newNanoFrameworkDevice.ConnectionPort.ConnectDevice())
                             {
-                                await Task.Yield();
                                 if (await CheckValidNanoFrameworkSerialDeviceAsync(newNanoFrameworkDevice))
                                 {
                                     //add device to the collection

--- a/nanoFramework.Tools.DebugLibrary.Shared/PortUSB/UsbPort.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortUSB/UsbPort.cs
@@ -437,7 +437,7 @@ namespace nanoFramework.Tools.Debugger.Usb
 
         #endregion
 
-        public Task<bool> ConnectDeviceAsync()
+        public Task<bool> ConnectDevice()
         {
             return ConnectUsbDeviceAsync(null);
         }
@@ -477,7 +477,7 @@ namespace nanoFramework.Tools.Debugger.Usb
             EventHandlerForUsbDevice.Current.CloseDevice();
         }
 
-        public async Task<uint> SendBufferAsync(byte[] buffer, TimeSpan waiTimeout, CancellationToken cancellationToken)
+        public uint SendBuffer(byte[] buffer, TimeSpan waiTimeout, CancellationToken cancellationToken)
         {
             uint bytesWritten = 0;
 
@@ -523,7 +523,7 @@ namespace nanoFramework.Tools.Debugger.Usb
                         storeAsyncTask = writer.StoreAsync().AsTask(linkedCancelationToken);
                     }
 
-                    bytesWritten = await storeAsyncTask;
+                    bytesWritten = storeAsyncTask.GetAwaiter().GetResult();
 
                     if (bytesWritten > 0)
                     {
@@ -548,7 +548,7 @@ namespace nanoFramework.Tools.Debugger.Usb
             return bytesWritten;
         }
 
-        public async Task<byte[]> ReadBufferAsync(uint bytesToRead, TimeSpan waiTimeout, CancellationToken cancellationToken)
+        public byte[] ReadBuffer(uint bytesToRead, TimeSpan waiTimeout, CancellationToken cancellationToken)
         {
             // device must be connected
             if (EventHandlerForUsbDevice.Current.IsDeviceConnected)
@@ -574,7 +574,7 @@ namespace nanoFramework.Tools.Debugger.Usb
 
                 Task<UInt32> loadAsyncTask;
 
-                await semaphore.WaitAsync();
+                //await semaphore.WaitAsync();
 
                 try
                 {
@@ -602,7 +602,7 @@ namespace nanoFramework.Tools.Debugger.Usb
                         if (readCount > 0 &&
                             bytesToRead > 0)
                         {
-                            await reader.LoadAsync(readCount);
+                            _ = reader.LoadAsync(readCount).AsTask().GetAwaiter().GetResult();
 
                             byte[] readBuffer = new byte[bytesToRead];
                             reader.ReadBytes(readBuffer);

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Controller.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Controller.cs
@@ -62,7 +62,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             try
             {
                 // TX header
-                var sendHeaderCount = await SendRawBufferAsync(raw.Header, TimeSpan.FromMilliseconds(1000), cancellationToken);
+                var sendHeaderCount = SendRawBufferAsync(raw.Header, TimeSpan.FromMilliseconds(1000), cancellationToken);
 
                 // check for cancellation request
                 if (cancellationToken.IsCancellationRequested)
@@ -76,7 +76,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                     // we have a payload to TX
                     if (sendHeaderCount == raw.Header.Length)
                     {
-                        var sendPayloadCount = await SendRawBufferAsync(raw.Payload, TimeSpan.FromMilliseconds(1000), cancellationToken);
+                        var sendPayloadCount = SendRawBufferAsync(raw.Payload, TimeSpan.FromMilliseconds(1000), cancellationToken);
 
                         if (sendPayloadCount == raw.Payload.Length)
                         {
@@ -107,7 +107,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             }
             catch (DeviceNotConnectedException)
             {
-                App.ProcessExited();
+                throw;
             }
             catch (AggregateException)
             {
@@ -150,9 +150,9 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             throw new NotImplementedException();
         }
 
-        private async Task<uint> SendRawBufferAsync(byte[] buffer, TimeSpan waiTimeout, CancellationToken cancellationToken)
+        private uint SendRawBufferAsync(byte[] buffer, TimeSpan waiTimeout, CancellationToken cancellationToken)
         {
-            return await App.SendBufferAsync(buffer, waiTimeout, cancellationToken);
+            return App.SendBuffer(buffer, waiTimeout, cancellationToken);
         }
 
         internal async Task<int> ReadBufferAsync(byte[] buffer, int offset, int bytesToRead, TimeSpan waitTimeout, CancellationToken cancellationToken)
@@ -182,7 +182,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 while (bytesToRead > 0 && !cancellationToken.IsCancellationRequested)
                 {
                     // read next chunk of data async
-                    var readResult = await App.ReadBufferAsync((uint)bytesToRead, waitTimeout, cancellationToken);
+                    var readResult = App.ReadBuffer((uint)bytesToRead, waitTimeout, cancellationToken);
 
                     // any byte read?
                     if (readResult.Length > 0)
@@ -196,7 +196,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             }
             catch (DeviceNotConnectedException)
             {
-                App.ProcessExited();
+                throw;
             }
             catch (TaskCanceledException)
             {

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/IControllerHostLocal.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/IControllerHostLocal.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace nanoFramework.Tools.Debugger.WireProtocol
 {
@@ -14,9 +13,9 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
     {
         bool ProcessMessage(IncomingMessage msg, bool fReply);
 
-        Task<uint> SendBufferAsync(byte[] buffer, TimeSpan waitTimeout, CancellationToken cancellationToken);
+        uint SendBuffer(byte[] buffer, TimeSpan waitTimeout, CancellationToken cancellationToken);
 
-        Task<byte[]> ReadBufferAsync(uint bytesToRead, TimeSpan waitTimeout, CancellationToken cancellationToken);
+        byte[] ReadBuffer(uint bytesToRead, TimeSpan waitTimeout, CancellationToken cancellationToken);
     }
 }
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.24.0-preview.{height}",
+  "version": "1.25.0-preview.{height}",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
## Description
- Rework SendBuffer and ReadBuffer to remove async calls and to throw DeviceNotConnectedException exception.
- Rework initial SerialDevice detection.
- Remove Async suffix from several APIs.
- Bump version to 1.25.0-preview.

## Motivation and Context
- Improve stability on the communication an discovery of devices.

## How Has This Been Tested?<!-- (if applicable) -->
- Test apps in solution.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
