### PR TITLE
Add attempts parameter to ConnectAsync

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
+++ b/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
@@ -16,6 +16,8 @@
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <!-- need this here to rebuild the packages.lock.json file in case the hashes fail to validate -->
+    <!-- <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder> -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -80,6 +82,9 @@
     </PackageReference>
     <PackageReference Include="Polly">
       <Version>7.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Polly.Contrib.WaitAndRetry">
+      <Version>1.1.1</Version>
     </PackageReference>
     <PackageReference Include="PropertyChanged.Fody">
       <Version>2.6.1</Version>

--- a/nanoFramework.Tools.DebugLibrary.Net/packages.lock.json
+++ b/nanoFramework.Tools.DebugLibrary.Net/packages.lock.json
@@ -30,6 +30,12 @@
         "resolved": "7.2.1",
         "contentHash": "Od8SnPlpQr+PuAS0YzY3jgtzaDNknlIuAaldN2VEIyTvm/wCg22C5nUkUV1BEG8rIsub5RFMoV/NEQ0tM/+7Uw=="
       },
+      "Polly.Contrib.WaitAndRetry": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "1MUQLiSo4KDkQe6nzQRhIU05lm9jlexX5BVsbuw0SL82ynZ+GzAHQxJVDPVBboxV37Po3SG077aX8DuSy8TkaA=="
+      },
       "PropertyChanged.Fody": {
         "type": "Direct",
         "requested": "[2.6.1, )",

--- a/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
@@ -334,7 +334,11 @@ namespace nanoFramework.Tools.Debugger
                             CreateDebugEngine();
                         }
 
-                        if (fConnected = await DebugEngine.ConnectAsync(1000, true, ConnectionSource.Unknown))
+                        if (fConnected = await DebugEngine.ConnectAsync(
+                            1000,
+                            true,
+                            3,
+                            ConnectionSource.Unknown))
                         {
                             Commands.Monitor_Ping.Reply reply = DebugEngine.GetConnectionSource();
 

--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPortManager.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/SerialPortManager.cs
@@ -576,6 +576,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                             if (await device.DebugEngine.ConnectAsync(
                                 200,
                                 false,
+                                1,
                                 ConnectionSource.Unknown,
                                 false))
                             {

--- a/nanoFramework.Tools.DebugLibrary.UWP/nanoFramework.Tools.DebugLibrary.UWP.csproj
+++ b/nanoFramework.Tools.DebugLibrary.UWP/nanoFramework.Tools.DebugLibrary.UWP.csproj
@@ -17,6 +17,8 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <!-- need this here to rebuild the packages.lock.json file in case the hashes fail to validate -->
+    <!-- <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder> -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -158,7 +160,7 @@
   </ItemGroup>
   <Import Project="..\nanoFramework.Tools.DebugLibrary.Shared\nanoFramework.Tools.DebugLibrary.Net.projitems" Label="Shared" />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
-    <VisualStudioVersion>14.0</VisualStudioVersion>
+    <VisualStudioVersion>15.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/nanoFramework.Tools.DebugLibrary.UWP/packages.lock.json
+++ b/nanoFramework.Tools.DebugLibrary.UWP/packages.lock.json
@@ -26,6 +26,12 @@
         "resolved": "7.2.1",
         "contentHash": "Od8SnPlpQr+PuAS0YzY3jgtzaDNknlIuAaldN2VEIyTvm/wCg22C5nUkUV1BEG8rIsub5RFMoV/NEQ0tM/+7Uw=="
       },
+      "Polly.Contrib.WaitAndRetry": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "1MUQLiSo4KDkQe6nzQRhIU05lm9jlexX5BVsbuw0SL82ynZ+GzAHQxJVDPVBboxV37Po3SG077aX8DuSy8TkaA=="
+      },
       "PropertyChanged.Fody": {
         "type": "Direct",
         "requested": "[2.6.1, )",
@@ -85,7 +91,7 @@
       "NETStandard.Library": {
         "type": "Transitive",
         "resolved": "2.0.3",
-        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "contentHash": "548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
         }


### PR DESCRIPTION
## Description
- Add Polly wait and retry policy to perform repeated attempts to connect to a device.

## Motivation and Context
- Improve operation robustness and resilience to failure by taking the responsibility to retry the operation, instead of being the client app.

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
