### PR TITLE
StopDebuggerOnConnect shouldn't resume execution

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -291,12 +291,6 @@ namespace nanoFramework.Tools.Debugger
                             {
                                 SetExecutionMode(Commands.DebuggingExecutionChangeConditions.State.DebuggerQuiet, 0);
                             }
-
-                            // resume execution for older clients, since server tools no longer do this.
-                            if (!StopDebuggerOnConnect && (msg != null && msg.Payload == null))
-                            {
-                                ResumeExecution();
-                            }
                         }
                     }
                 }
@@ -397,12 +391,6 @@ namespace nanoFramework.Tools.Debugger
                 if (m_silent)
                 {
                     SetExecutionMode(Commands.DebuggingExecutionChangeConditions.State.DebuggerQuiet, 0);
-                }
-
-                // resume execution for older clients, since server tools no longer do this.
-                if (!StopDebuggerOnConnect && msg?.Payload == null)
-                {
-                    ResumeExecution();
                 }
 
                 // done here


### PR DESCRIPTION
## Description
- Remove this on ConnectAsync and update debugger flags.

## Motivation and Context
- This is not required for properly launch a debug session. Actually it prevents exceptions thrown at early stages of boot sequence to be showned on VS output window.

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
