### PR TITLE
Fix initialization of Expires in WP Request

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/PortSerialManager.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/PortSerialManager.cs
@@ -611,7 +611,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                     }
                 }
             }
-            catch
+            catch (Exception /* ex */)   // we could eat simple programming errors here - like a bad cast or other problem when changing code
             {
                 // "catch all" required because the device open & check calls might fail for a number of reasons
                 // if there is a deviceID, remove it from cache, just in case

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -1388,7 +1388,7 @@ namespace nanoFramework.Tools.Debugger
 
 #region Commands implementation
 
-        private List<Commands.Monitor_MemoryMap.Range> GetMemoryMap()
+        public List<Commands.Monitor_MemoryMap.Range> GetMemoryMap()
         {
             Commands.Monitor_MemoryMap cmd = new Commands.Monitor_MemoryMap();
 
@@ -1461,7 +1461,7 @@ namespace nanoFramework.Tools.Debugger
             return null;
         }
 
-        private List<Commands.Monitor_FlashSectorMap.FlashSectorData> GetFlashSectorMap()
+        public List<Commands.Monitor_FlashSectorMap.FlashSectorData> GetFlashSectorMap()
         {
             IncomingMessage reply = PerformSyncRequest(Commands.c_Monitor_FlashSectorMap, 0, null);
 

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/WireProtocolRequest.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/WireProtocolRequest.cs
@@ -19,7 +19,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         public CancellationToken CancellationToken { get; }
         public TaskCompletionSource<IncomingMessage> TaskCompletionSource { get; }
 
-        public DateTimeOffset Expires { get; private set; } = DateTime.MaxValue;
+        public DateTimeOffset Expires { get; private set; } = DateTimeOffset.MaxValue;
 
         public DateTime RequestTimestamp { get; private set; }
 


### PR DESCRIPTION
Logic was using DateTime.MaxValue which could establish a value that is later adjusted for time zone.  DateTimeOffset.MaxValue is already set to UTC which is the default for DateTimeOffset.

Additional problem was in Engine.cs - there are a couple of of commands that are used in the test harness that need to be declared as public so they can be tested.

Added some comments in PortSerialManager.cs about the possibility of eating non-serial problems in the try/catch block.

Fix #742

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
1.   Initialized Expires with DateTimeOffset.MaxValue instead of DateTime.MaxValue
2. Changed two interfaces to public to allow testing with the test harness that is in the repo
3. Documented via comment that the open catch in the try/catch could hide programming mistakes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Fixes nanoFramework/Home#742

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using the Serial Test App WPF project that is in the nf-debugger repository and is part of the nanoFramework.Tools.Debugger solution file.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
