### PR TITLE
Improve WP request send

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Controller.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Controller.cs
@@ -13,6 +13,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
     public class Controller : IControllerLocal
     {
         private ushort lastOutboundMessage;
+        private DateTime _lastActivity;
         private readonly int nextEndpointId;
         private readonly object incrementLock = new object();
 
@@ -41,6 +42,24 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         private void ProcessExit()
         {
             App.ProcessExited();
+        }
+
+        public DateTime LastActivity
+        {
+            get
+            {
+                return _lastActivity;
+            }
+
+            internal set
+            {
+                _lastActivity = value;
+            }
+        }
+
+        public bool IsIdle()
+        {
+            return (DateTime.UtcNow - _lastActivity).TotalMilliseconds > 100;
         }
 
         public bool Send(MessageRaw raw)

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -526,12 +526,8 @@ namespace nanoFramework.Tools.Debugger
         {
             get
             {
-                //return m_portDefinition.LastActivity;
-                throw new NotImplementedException();
-
+                return _controlller.LastActivity;
             }
-
-            set { }
         }
 
         public bool ThrowOnCommunicationFailure { get; set; } = false;

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/IController.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/IController.cs
@@ -27,5 +27,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         Converter CreateConverter();
 
         bool Send(MessageRaw raw);
+
+        bool IsIdle();
     }
 }

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/IControllerHost.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/IControllerHost.cs
@@ -10,8 +10,6 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 {
     public interface IControllerHost
     {
-        DateTime LastActivity { get; set; }
-
         bool IsConnected { get; }
 
         bool IsCRC32EnabledForWireProtocol { get; }

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/WireProtocolRequest.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/WireProtocolRequest.cs
@@ -40,6 +40,12 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
         internal bool PerformRequest(IController controller)
         {
+            // wait for controller to be idle
+            while(!controller.IsIdle())
+            {
+                Thread.Sleep(10);
+            }
+
             Debug.WriteLine($"Performing request");
 
             DebuggerEventSource.Log.WireProtocolTxHeader(OutgoingMessage.Base.Header.CrcHeader


### PR DESCRIPTION
## Description
- Rework LastActivity in controllers and engine.
- It's now updated on MessageReassembler.
- Add new method IsIdle.
- PerformRequest now waits for controller to be idle before sending the packet.

## Motivation and Context
- Addresses nanoFramework/Home#755

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
