### PR TITLE
Improvements in device detection

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
@@ -27,13 +27,30 @@ namespace nanoFramework.Tools.Debugger
         public Engine DebugEngine { get; set; }
 
         /// <summary>
-        /// Create a new debug engine for this nanoDevice.
+        /// Creates a new debug engine for this nanoDevice.
         /// </summary>
-        /// <param name="timeoutMilliseconds"></param>
-        public void CreateDebugEngine(int timeoutMilliseconds = 5000)
+        public void CreateDebugEngine()
         {
             DebugEngine = new Engine(this);
-            DebugEngine.DefaultTimeout = timeoutMilliseconds;
+
+            if (Transport == TransportType.Serial)
+            {
+                DebugEngine.DefaultTimeout = NanoSerialDevice.SafeDefaultTimeout;
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        /// <summary>
+        /// Creates a new debug engine for this nanoDevice.
+        /// </summary>
+        /// <param name="timeoutMilliseconds"></param>
+        public void CreateDebugEngine(int timeoutMilliseconds)
+        {
+            DebugEngine = new Engine(this);
+            DebugEngine.DefaultTimeout = NanoSerialDevice.SafeDefaultTimeout;
         }
 
         /// <summary>
@@ -316,7 +333,6 @@ namespace nanoFramework.Tools.Debugger
                         }
 
                         if (fConnected = DebugEngine.Connect(
-                            1000,
                             true))
                         {
                             ret = (DebugEngine.GetConnectionSource() == ConnectionSource.nanoBooter);


### PR DESCRIPTION
## Description
- Second attempt to check valid device is now using twice the safe timeout.
- Remove unnecessary settings on SeriaPort and also call to Open(). All this is now performed by Connect().
- Add new method for creating a debug engine without a timeout which will use the safe timeout of the device type.

## Motivation and Context
- Improving device detection.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
