### PR TITLE
General improvements

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
@@ -377,20 +377,6 @@ namespace nanoFramework.Tools.Debugger
                 return false;
             }
 
-            // check if the device is responsive
-            if (Ping() == ConnectionSource.Unknown)
-            {
-                log?.Report("Device not responding, attempting to reconnect...");
-
-                // it's not, try reconnect
-                if (!DebugEngine.Connect())
-                {
-                    log?.Report("*** ERROR: failed to reconnect to device ***");
-
-                    return false;
-                }
-            }
-
             if (!IsCLRDebuggerEnabled || 0 != (options & EraseOptions.Firmware))
             {
                 log?.Report("Connecting to nanoBooter...");

--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/PortSerialManager.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/PortSerialManager.cs
@@ -486,14 +486,17 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                             ((SerialPort)device.DeviceBase).BaudRate = baudRate;
                         }
 
+                        // better flush the UART FIFOs
+                        ((SerialPort)device.DeviceBase).DiscardInBuffer();
+                        ((SerialPort)device.DeviceBase).DiscardOutBuffer();
+
                         OnLogMessageAvailable(NanoDevicesEventSource.Log.CheckingValidDevice($" {deviceId} @ { baudRate }"));
 
                         // try to "just" connect to the device meaning...
                         // ... don't request capabilities or force anything except the absolute minimum required, plus...
                         // ... it's OK to use a very short timeout as we'll be exchanging really short packets with the device
                         if (device.DebugEngine.Connect(
-                            longDelay ? 2 * NanoSerialDevice.SafeDefaultTimeout : NanoSerialDevice.SafeDefaultTimeout,
-                            true))
+                            longDelay ? 2 * NanoSerialDevice.SafeDefaultTimeout : NanoSerialDevice.SafeDefaultTimeout))
                         {
                             if (isKnownDevice)
                             {

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -431,7 +431,7 @@ namespace nanoFramework.Tools.Debugger
                 Commands.Monitor_Ping cmd = new Commands.Monitor_Ping
                 {
                     Source = Commands.Monitor_Ping.c_Ping_Source_Host,
-                    Flags = (StopDebuggerOnConnect ? Commands.Monitor_Ping.c_Ping_DbgFlag_Stop : 0)
+                    Flags = StopDebuggerOnConnect ? Commands.Monitor_Ping.c_Ping_DbgFlag_Stop : 0
                 };
 
                 IncomingMessage msg = PerformSyncRequest(Commands.c_Monitor_Ping, Flags.c_NoCaching, cmd);
@@ -446,7 +446,7 @@ namespace nanoFramework.Tools.Debugger
                 }
 
                 // get state flags to set
-                var stateFlagsToSet = Commands.DebuggingExecutionChangeConditions.State.SourceLevelDebugging;
+                Commands.DebuggingExecutionChangeConditions.State stateFlagsToSet = Commands.DebuggingExecutionChangeConditions.State.SourceLevelDebugging;
 
                 if (Silent)
                 {
@@ -1897,6 +1897,9 @@ namespace nanoFramework.Tools.Debugger
                 {
                     if (cmdReply.CurrentState != (uint)Commands.DebuggingExecutionChangeConditions.State.Unknown)
                     {
+                        // need to let the device settle after the command is executed
+                        Thread.Sleep(500);
+
                         return true;
                     }
                 }


### PR DESCRIPTION
## Description
- Erase memory doesn't ping device anymore (no need to find if it's responsive).
- Detection clears buffers to make sure there is nothing preventing a correct communication with the device.
- No need to force connect on detection.
- Setting execution flags now has a delay of 500ms before returning to allow the target to settle with the new conditions.

## Motivation and Context
- Improves device detection and communication workflow.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
