### PR TITLE
Fix packet size for targets requiring program alignment

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -1559,7 +1559,7 @@ namespace nanoFramework.Tools.Debugger
                 // get packet length, either the maximum allowed size or whatever is still available to TX
                 int packetLength = Math.Min(GetPacketMaxLength(cmd), count);
 
-                if(programAligment != 0 && packetLength % programAligment != 0)
+                if(programAligment != 0 && packetLength % programAligment != 0 && packetLength > programAligment)
                 {
                     packetLength -= packetLength % programAligment;
                 }
@@ -1568,7 +1568,7 @@ namespace nanoFramework.Tools.Debugger
 
                 DebuggerEventSource.Log.EngineWriteMemory(address, packetLength);
 
-                IncomingMessage reply = PerformSyncRequest(Commands.c_Monitor_WriteMemory, 0, cmd);
+                IncomingMessage reply = PerformSyncRequest(Commands.c_Monitor_WriteMemory, 0, cmd, 2 * DefaultTimeout);
 
                 if (reply != null)
                 {


### PR DESCRIPTION
## Description
- Packet size algorithm was failing to handle packet size smaller than the program aliment size.
- Change default timeout for write memory to twice the default timeout.

## Motivation and Context
- When buffer size had the last chunk of data smaller than the program alignment size, this ended on a endless loop wrongly sending a zero sized packet to wrap up the operation.
- For packets of a large size in MCUs that have long flash write times, this could result on timeout errors causing the operation to fail.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
