### PR TITLE
Add UNIX support for PortSerial

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/DeviceWatcher.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/DeviceWatcher.cs
@@ -2,8 +2,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.IO.Ports;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -86,7 +88,125 @@ namespace nanoFramework.Tools.Debugger.PortSerial
             }
         }
 
-        private List<string> GetPortNames()
+        public List<string> GetPortNames()
+        {
+
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? GetPortNames_Linux()
+                : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? GetPortNames_OSX()
+                : RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")) ? GetPortNames_FreeBSD()
+                : GetPortNamesWindows();
+        }
+
+        private List<string> GetPortNames_Linux()
+        {
+            const string sysTtyDir = "/sys/class/tty";
+            const string sysUsbDir = "/sys/bus/usb-serial/devices/";
+            const string devDir = "/dev/";
+
+            if (Directory.Exists(sysTtyDir))
+            {
+                // /sys is mounted. Let's explore tty class and pick active nodes.
+                List<string> ports = new List<string>();
+                DirectoryInfo di = new DirectoryInfo(sysTtyDir);
+                var entries = di.EnumerateFileSystemInfos(@"*", SearchOption.TopDirectoryOnly);
+                foreach (var entry in entries)
+                {
+                    // /sys/class/tty contains some bogus entries such as console, tty
+                    // and a lot of bogus ttyS* entries mixed with correct ones.
+                    // console and tty can be filtered out by checking for presence of device/tty
+                    // ttyS entries pass this check but those can be filtered out
+                    // by checking for presence of device/id or device/of_node
+                    // checking for that for non-ttyS entries is incorrect as some uart
+                    // devices are incorrectly filtered out
+                    bool isTtyS = entry.Name.StartsWith("ttyS", StringComparison.Ordinal);
+                    bool isTtyGS = !isTtyS && entry.Name.StartsWith("ttyGS", StringComparison.Ordinal);
+                    if ((isTtyS &&
+                         (File.Exists(entry.FullName + "/device/id") ||
+                          Directory.Exists(entry.FullName + "/device/of_node"))) ||
+                        (!isTtyS && Directory.Exists(entry.FullName + "/device/tty")) ||
+                        Directory.Exists(sysUsbDir + entry.Name) ||
+                        (isTtyGS && (File.Exists(entry.FullName + "/dev"))))
+                    {
+                        string deviceName = devDir + entry.Name;
+                        if (File.Exists(deviceName))
+                        {
+                            ports.Add(deviceName);
+                        }
+                    }
+                }
+
+                return ports;
+            }
+            else
+            {
+                // Fallback to scanning /dev. That may have more devices then needed.
+                // This can also miss usb or serial devices with non-standard name.
+                var ports = new List<string>();
+                foreach (var portName in Directory.EnumerateFiles(devDir, "tty*"))
+                {
+                    if (portName.StartsWith("/dev/ttyS", StringComparison.Ordinal) ||
+                        portName.StartsWith("/dev/ttyUSB", StringComparison.Ordinal) ||
+                        portName.StartsWith("/dev/ttyACM", StringComparison.Ordinal) ||
+                        portName.StartsWith("/dev/ttyAMA", StringComparison.Ordinal) ||
+                        portName.StartsWith("/dev/ttymxc", StringComparison.Ordinal))
+                    {
+                        ports.Add(portName);
+                    }
+                }
+
+                return ports;
+            }
+        }
+
+        private List<string> GetPortNames_OSX()
+        {
+            List<string> ports = new List<string>();
+
+            foreach (string name in Directory.GetFiles("/dev", "tty.usbserial*"))
+            {
+                // GetFiles can return unexpected results because of 8.3 matching.
+                // Like /dev/tty
+                if (name.StartsWith("/dev/tty.", StringComparison.Ordinal))
+                {
+                    ports.Add(name);
+                }
+            }
+
+            foreach (string name in Directory.GetFiles("/dev", "cu.usbserial*"))
+            {
+                if (name.StartsWith("/dev/cu.", StringComparison.Ordinal))
+                {
+                    ports.Add(name);
+                }
+            }
+
+            return ports;
+        }
+
+        private List<string> GetPortNames_FreeBSD()
+        {
+            List<string> ports = new List<string>();
+
+            foreach (string name in Directory.GetFiles("/dev", "ttyd*"))
+            {
+                if (!name.EndsWith(".init", StringComparison.Ordinal) && !name.EndsWith(".lock", StringComparison.Ordinal))
+                {
+                    ports.Add(name);
+                }
+            }
+
+            foreach (string name in Directory.GetFiles("/dev", "cuau*"))
+            {
+                if (!name.EndsWith(".init", StringComparison.Ordinal) && !name.EndsWith(".lock", StringComparison.Ordinal))
+                {
+                    ports.Add(name);
+                }
+            }
+
+            return ports;
+        }
+
+        private List<string> GetPortNamesWindows()
         {
             const string FindFullPathPattern = @"\\\\\?\\([\w]*)#([\w&]*)#([\w&]*)";
             const string RegExPattern = @"\\Device\\([a-zA-Z]*)(\d)";

--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/DeviceWatcher.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/DeviceWatcher.cs
@@ -94,7 +94,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
             return RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? GetPortNames_Linux()
                 : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? GetPortNames_OSX()
                 : RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")) ? GetPortNames_FreeBSD()
-                : GetPortNamesWindows();
+                : GetPortNames_Windows();
         }
 
         private List<string> GetPortNames_Linux()
@@ -206,7 +206,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
             return ports;
         }
 
-        private List<string> GetPortNamesWindows()
+        private List<string> GetPortNames_Windows()
         {
             const string FindFullPathPattern = @"\\\\\?\\([\w]*)#([\w&]*)#([\w&]*)";
             const string RegExPattern = @"\\Device\\([a-zA-Z]*)(\d)";


### PR DESCRIPTION
## Description
Extended `GetPortNames()` to support UNIX (Linux/OSX/FreeBSD) runtime environments:
-  Added `GetPortNames_Linux()`.
-  Added `GetPortNames_OSX()`.
-  Added `GetPortNames_FreeBSD()`.
-  Unchanged `GetPortNames_Windows()`.

## Motivation and Context
When testing a deployment using Mono on macOS, the DeviceEnumeration never completed which is because nf-debugger is only supported on Windows. This change adds support for devices connected on UNIX machines.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested successfully on macOS to erase & flash a device using nf-debugger:
![MicrosoftTeams-image](https://user-images.githubusercontent.com/6081141/134322014-5dc0accc-b29c-4369-9e6b-450a1778577d.png)

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
