### PR TITLE
Improved Linux SerialPort lookup

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/DeviceWatcher.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/DeviceWatcher.cs
@@ -99,63 +99,23 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
         private List<string> GetPortNames_Linux()
         {
-            const string sysTtyDir = "/sys/class/tty";
-            const string sysUsbDir = "/sys/bus/usb-serial/devices/";
-            const string devDir = "/dev/";
+            List<string> ports = new List<string>();
 
-            if (Directory.Exists(sysTtyDir))
+            string[] ttys = System.IO.Directory.GetFiles("/dev/", "tty*");
+            foreach (string dev in ttys)
             {
-                // /sys is mounted. Let's explore tty class and pick active nodes.
-                List<string> ports = new List<string>();
-                DirectoryInfo di = new DirectoryInfo(sysTtyDir);
-                var entries = di.EnumerateFileSystemInfos(@"*", SearchOption.TopDirectoryOnly);
-                foreach (var entry in entries)
+                if (dev.StartsWith("/dev/ttyS")
+                    || dev.StartsWith("/dev/ttyUSB")
+                    || dev.StartsWith("/dev/ttyACM")
+                    || dev.StartsWith("/dev/ttyAMA")
+                    || dev.StartsWith("/dev/ttyPS")
+                    || dev.StartsWith("/dev/serial"))
                 {
-                    // /sys/class/tty contains some bogus entries such as console, tty
-                    // and a lot of bogus ttyS* entries mixed with correct ones.
-                    // console and tty can be filtered out by checking for presence of device/tty
-                    // ttyS entries pass this check but those can be filtered out
-                    // by checking for presence of device/id or device/of_node
-                    // checking for that for non-ttyS entries is incorrect as some uart
-                    // devices are incorrectly filtered out
-                    bool isTtyS = entry.Name.StartsWith("ttyS", StringComparison.Ordinal);
-                    bool isTtyGS = !isTtyS && entry.Name.StartsWith("ttyGS", StringComparison.Ordinal);
-                    if ((isTtyS &&
-                         (File.Exists(entry.FullName + "/device/id") ||
-                          Directory.Exists(entry.FullName + "/device/of_node"))) ||
-                        (!isTtyS && Directory.Exists(entry.FullName + "/device/tty")) ||
-                        Directory.Exists(sysUsbDir + entry.Name) ||
-                        (isTtyGS && (File.Exists(entry.FullName + "/dev"))))
-                    {
-                        string deviceName = devDir + entry.Name;
-                        if (File.Exists(deviceName))
-                        {
-                            ports.Add(deviceName);
-                        }
-                    }
+                    ports.Add(dev);
                 }
-
-                return ports;
             }
-            else
-            {
-                // Fallback to scanning /dev. That may have more devices then needed.
-                // This can also miss usb or serial devices with non-standard name.
-                var ports = new List<string>();
-                foreach (var portName in Directory.EnumerateFiles(devDir, "tty*"))
-                {
-                    if (portName.StartsWith("/dev/ttyS", StringComparison.Ordinal) ||
-                        portName.StartsWith("/dev/ttyUSB", StringComparison.Ordinal) ||
-                        portName.StartsWith("/dev/ttyACM", StringComparison.Ordinal) ||
-                        portName.StartsWith("/dev/ttyAMA", StringComparison.Ordinal) ||
-                        portName.StartsWith("/dev/ttymxc", StringComparison.Ordinal))
-                    {
-                        ports.Add(portName);
-                    }
-                }
 
-                return ports;
-            }
+            return ports;
         }
 
         private List<string> GetPortNames_OSX()


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Improved Linux SerialPort lookup to have better support for devices connected on /dev/ttyUSB, /dev/ttyACM and /dev/ttyAMA.

## Motivation and Context
When trying to enumerate the devices on Raspbian, the device was available under /dev/ttyUSB0 but previously these ports were never scanned because it was only scanning /dev/ttyGS and /dev/ttyS.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Improvement (non-breaking change that improves a feature, code or algorithm)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.