### PR TITLE
Add processing for bad WP packets

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -901,6 +901,18 @@ namespace nanoFramework.Tools.Debugger
             return false;
         }
 
+        public void ReplyBadPacket(uint flags)
+        {
+            PerformRequestAsync(
+                new OutgoingMessage(
+                    _controlller.GetNextSequenceId(),
+                    _controlller.CreateConverter(),
+                    Commands.c_Monitor_Ping,
+                    flags | Flags.c_NonCritical | Flags.c_NACK,
+                    null)
+                );
+        }
+
         public void SpuriousCharacters(byte[] buf, int offset, int count)
         {
             m_lastNoise = DateTime.Now;

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/IControllerHostLocal.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/IControllerHostLocal.cs
@@ -17,6 +17,8 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         byte[] ReadBuffer(int bytesToRead);
 
         int AvailableBytes { get; }
+
+        void ReplyBadPacket(uint flags);
     }
 }
 

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/MessageReassembler.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/MessageReassembler.cs
@@ -330,6 +330,11 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
                         DebuggerEventSource.Log.WireProtocolReceiveState(_state);
 
+                        if ((_messageBase.Header.Flags & Flags.c_NonCritical) == 0)
+                        {
+                            _parent.App.ReplyBadPacket(Flags.c_BadHeader);
+                        }
+
                         break;
 
                     case ReceiveState.ReadingPayload:
@@ -412,6 +417,11 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                         _state = ReceiveState.Initialize;
 
                         DebuggerEventSource.Log.WireProtocolReceiveState(_state);
+
+                        if ((_messageBase.Header.Flags & Flags.c_NonCritical) == 0)
+                        {
+                            _parent.App.ReplyBadPacket(Flags.c_BadPayload);
+                        }
 
                         break;
                 }


### PR DESCRIPTION
## Description
- Add code to process bad header and bad payload.
- Add implementation to report this back to the device.
- Support in device WP processor implemented with nanoframework/nf-interpreter#2162.

## Motivation and Context
- Allow WP state machine to receive reply on bad packet/payload instead of relying on timeout to move forward.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
