### PR TITLE
Add parameter to network port managers to control watchers

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Net/PortDefinitions/PortBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Net/PortDefinitions/PortBase.cs
@@ -32,19 +32,19 @@ namespace nanoFramework.Tools.Debugger
             return new PortSerialManager(startDeviceWatchers, portExclusionList, bootTime);
         }
         
-        public static PortBase CreateInstanceForNetwork()
+        public static PortBase CreateInstanceForNetwork(bool startDeviceWatchers)
         {
-            return new PortTcpIpDeviceManager();
+            return new PortTcpIpDeviceManager(startDeviceWatchers);
         }
         
-        public static PortBase CreateInstanceForNetwork(int discoveryPort)
+        public static PortBase CreateInstanceForNetwork(bool startDeviceWatchers, int discoveryPort)
         {
-            return new PortTcpIpDeviceManager(true, discoveryPort);
+            return new PortTcpIpDeviceManager(startDeviceWatchers, discoveryPort);
         }
         
-        public static PortBase CreateInstanceForComposite(IEnumerable<PortBase> ports)
+        public static PortBase CreateInstanceForComposite(IEnumerable<PortBase> ports, bool startDeviceWatchers)
         {
-            return new PortCompositeDeviceManager(ports);
+            return new PortCompositeDeviceManager(ports, startDeviceWatchers);
         }
     }
 }

--- a/nanoFramework.Tools.DebugLibrary.Shared/PortComposite/PortCompositeDeviceManager.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortComposite/PortCompositeDeviceManager.cs
@@ -18,13 +18,24 @@ namespace nanoFramework.Tools.Debugger.PortComposite
         public override event EventHandler DeviceEnumerationCompleted;
         public override event EventHandler<StringEventArgs> LogMessageAvailable;
 
-        public PortCompositeDeviceManager(IEnumerable<PortBase> ports)
+        public PortCompositeDeviceManager(
+            IEnumerable<PortBase> ports,
+            bool startDeviceWatchers = true)
         {
             NanoFrameworkDevices = new ObservableCollection<NanoDeviceBase>();
 
             _ports.AddRange(ports);
 
             SubscribeToPortEvents();
+
+
+            Task.Factory.StartNew(() =>
+            {
+                if (startDeviceWatchers)
+                {
+                    _ports.ForEach(p => p.StartDeviceWatchers());
+                }
+            });
         }
 
         private void SubscribeToPortEvents()


### PR DESCRIPTION
## Description
- Add parameter to network port managers to control watchers.

## Motivation and Context
- The network ports where missing this parameter which was causing issues when being used in VS and with the composite port, because the start operations where overlapping as they run on different threads.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
