### PR TITLE
Remove idle check from WP requests

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Controller.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Controller.cs
@@ -17,6 +17,14 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         private readonly int nextEndpointId;
         private readonly object incrementLock = new object();
 
+        /// <summary>
+        /// Threshold for considering the communication channel idle.
+        /// </summary>
+        /// <remarks>
+        /// The default idle time is 100ms.
+        /// </remarks>
+        public TimeSpan IdleThreshold { get; set; } = TimeSpan.FromMilliseconds(100);
+
         public IControllerHostLocal App { get; internal set; }
 
         public CLRCapabilities Capabilities { get; set; }
@@ -59,7 +67,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
         public bool IsIdle()
         {
-            return (DateTime.UtcNow - _lastActivity).TotalMilliseconds > 50;
+            return (DateTime.UtcNow - _lastActivity).TotalMilliseconds > IdleThreshold.TotalMilliseconds;
         }
 
         public bool Send(MessageRaw raw)

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/WireProtocolRequest.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/WireProtocolRequest.cs
@@ -40,25 +40,6 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
         internal bool PerformRequest(IController controller)
         {
-            const int sleepTimeMs = 10;
-            int attemptsCount = 10000 / sleepTimeMs;
-
-            // wait for controller to be idle
-            while (
-                !controller.IsIdle() &&
-                attemptsCount > 0)
-            {
-                Thread.Sleep(10);
-
-                attemptsCount--;
-            }
-
-            if(attemptsCount == 0)
-            {
-                // timeout waiting for idle controller
-                return false;
-            }
-
             Debug.WriteLine($"Performing request");
 
             DebuggerEventSource.Log.WireProtocolTxHeader(OutgoingMessage.Base.Header.CrcHeader
@@ -93,7 +74,6 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 OutgoingMessage.Base.Header.Seq,
                 OutgoingMessage.Base.Header.SeqReply,
                 RequestTimestamp);
-
         }
     }
 }


### PR DESCRIPTION
## Description
- Remove sleep when performing WP requests.
- Add new property IdleThreshold to WP controller.

## Motivation and Context
- With the latest improvements in WP it doesn't seem to be needed anymore this workaround to improve communication reliability. 

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
