### PR TITLE
Rework PerformSyncRequest

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/WireProtocolRequest.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/WireProtocolRequest.cs
@@ -35,7 +35,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             _timeout = millisecondsTimeout;
 
             // https://blogs.msdn.microsoft.com/pfxteam/2009/06/02/the-nature-of-taskcompletionsourcetresult/
-            TaskCompletionSource = new TaskCompletionSource<IncomingMessage>();
+            TaskCompletionSource = new TaskCompletionSource<IncomingMessage>(this);
         }
 
         internal bool PerformRequest(IController controller)

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/WireProtocolRequestsStore.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/WireProtocolRequestsStore.cs
@@ -1,13 +1,17 @@
-﻿using System;
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace nanoFramework.Tools.Debugger.WireProtocol
 {
     public class WireProtocolRequestsStore
     {
         private readonly object _requestsLock = new object();
-        private readonly Dictionary<Tuple<uint, ushort>, WireProtocolRequest> _requests = new Dictionary<Tuple<uint, ushort>, WireProtocolRequest>();
+        private readonly Dictionary<Tuple<uint, ushort>, WireProtocolRequest> _requests = new();
 
         public void Add(WireProtocolRequest request)
         {
@@ -15,11 +19,12 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             {
                 // it's wise to check if this key is already on the dictionary
                 // can't use TryAdd because that's only available on the UWP API
-                var newKey = new Tuple<uint, ushort>(request.OutgoingMessage.Header.Cmd, request.OutgoingMessage.Header.Seq);
+                Tuple<uint, ushort> newKey = GetKey(request);
+
                 if (_requests.ContainsKey(newKey))
                 {
                     // remove the last one, before adding this
-                    _requests.Remove(newKey);
+                    _ = _requests.Remove(newKey);
                 }
 
                 _requests.Add(newKey, request);
@@ -31,6 +36,23 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             lock (_requestsLock)
             {
                 return _requests.Remove(new Tuple<uint, ushort>(header.Cmd, header.Seq));
+            }
+        }
+
+        public bool Remove(WireProtocolRequest request)
+        {
+            lock (_requestsLock)
+            {
+                if(_requests.Remove(GetKey(request)))
+                {
+                    request.RequestAborted();
+
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
             }
         }
 
@@ -50,12 +72,9 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             }
         }
 
-        public ICollection<WireProtocolRequest> FindAllToCancel()
+        private Tuple<uint, ushort> GetKey(WireProtocolRequest request)
         {
-            lock (_requestsLock)
-            {
-                return _requests.Values.Where(x => x.Expires < DateTime.UtcNow || x.CancellationToken.IsCancellationRequested).ToList();
-            }
+            return new Tuple<uint, ushort>(request.OutgoingMessage.Header.Cmd, request.OutgoingMessage.Header.Seq);
         }
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.1.0-preview.{height}",
+  "version": "2.2.0-preview.{height}",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
## Description
- PerformSyncRequest now use the same code.
- Replace lock with SemaphoreSlim.
- WireProtocolRequestsStore doesn't have timer to clean-up requests anymore.
- Requests are removed from store on Task.WaitAll failed.
- WireProtocolRequest now stores itself on TaskCompletionSource state.
- Tiny improvements in code from analysers.
- Bump version to 2.2.0-preview.

## Motivation and Context
- Following DRY principle.
- Improving code redability.
- Improving communication with nanoDevices.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
