### PR TITLE
Improve WriteMemory

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
@@ -704,14 +704,14 @@ namespace nanoFramework.Tools.Debugger
             int programAligment = 0,
             IProgress<string> progress = null)
         {
-            (AccessMemoryErrorCodes ErrorCode, bool Success) = DebugEngine.WriteMemory(
+            AccessMemoryErrorCodes errorCode = DebugEngine.WriteMemory(
                 address,
                 buffer,
                 programAligment);
 
-            if (!Success)
+            if (errorCode != AccessMemoryErrorCodes.NoError)
             {
-                progress?.Report($"Error writing to device memory @ 0x{address:X8}, error {ErrorCode}.");
+                progress?.Report($"Error writing to device memory @ 0x{address:X8}, error {errorCode}.");
 
                 return false;
             }

--- a/nanoFramework.Tools.DebugLibrary.Shared/Runtime/RuntimeValue_String.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/Runtime/RuntimeValue_String.cs
@@ -65,8 +65,9 @@ namespace nanoFramework.Tools.Debugger
                 throw new ArgumentException("String must have same length");
             }
 
-            var (ErrorCode, Success) = m_eng.WriteMemory(m_handle.m_charsInString, buf);
-            if (!Success)
+            WireProtocol.AccessMemoryErrorCodes errorCode = m_eng.WriteMemory(m_handle.m_charsInString, buf);
+            
+            if (errorCode != WireProtocol.AccessMemoryErrorCodes.NoError)
             {
                 throw new ArgumentException("Cannot write string");
             }


### PR DESCRIPTION
## Description
- Simplification of return, now uses AccessMemoryErrorCodes enum.
- Rework code accordingly.
- Sprinkle artificial thread sleeps to allow some slack in the channel.
- Add extra timeout in write operation.
- Rename and simplify PerformWriteMemoryCheck.
- Minor tweaks from analyser warnings and suggestions.

## Motivation and Context
- Improvements in deployment.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
