### PR TITLE
Add CanChangeMacAddress to CLR capabilites

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/CLRCapabilities.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/CLRCapabilities.cs
@@ -55,6 +55,11 @@ namespace nanoFramework.Tools.Debugger
             HasNanoBooter =             0x00001000,
 
             /// <summary>
+            /// This flag indicates that the MAC address of the target can be changed.
+            /// </summary>
+            CanChangeMacAddress =       0x00002000,
+
+            /// <summary>
             /// These bits are generic and are meant to be used to store platform specific capabilities.
             /// They should be parsed at the above layer to extract the real meaning out of them.
             /// </summary>
@@ -383,6 +388,15 @@ namespace nanoFramework.Tools.Debugger
             {
                 Debug.Assert(!m_fUnknown);
                 return (m_capabilities & Capability.HasNanoBooter) != 0;
+            }
+        }
+
+        public bool CanChangeMacAddress
+        {
+            get
+            {
+                Debug.Assert(!m_fUnknown);
+                return (m_capabilities & Capability.CanChangeMacAddress) != 0;
             }
         }
 

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -971,6 +971,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             public const uint c_CapabilityFlags_ThreadCreateEx =            0x00000400;
             public const uint c_CapabilityFlags_ConfigBlockRequiresErase =  0x00000800;
             public const uint c_CapabilityFlags_HasNanoBooter =             0x00001000;
+            public const uint c_CapabilityFlags_CanChangeMacAddress =       0x00002000;
 
             public const uint c_CapabilityFlags_PlatformCapabiliy_0 =       0x01000000;
             public const uint c_CapabilityFlags_PlatformCapabiliy_1 =       0x02000000;


### PR DESCRIPTION
## Description
- Add flag.
- Add property exposing it.

## Motivation and Context
- Exposes improvements from nanoframework/nf-interpreter#2277.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
