### PR TITLE
Fix network configuration serialization

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/DeviceConfiguration.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/DeviceConfiguration.cs
@@ -131,9 +131,9 @@ namespace nanoFramework.Tools.Debugger
             {
                 var addressAsArray = address.GetAddressBytes();
 
-                return (((uint)addressAsArray[3] << 24) | 
-                        ((uint)addressAsArray[2] << 16) | 
-                        ((uint)addressAsArray[1] << 8) | 
+                return (((uint)addressAsArray[3] << 24) |
+                        ((uint)addressAsArray[2] << 16) |
+                        ((uint)addressAsArray[1] << 8) |
                         (addressAsArray[0]));
             }
             catch { };
@@ -193,11 +193,11 @@ namespace nanoFramework.Tools.Debugger
 
                 if (value.SpecificConfigId == EmptySpecificConfigValue)
                 {
-                    SpecificConfigId =  null;
+                    SpecificConfigId = null;
                 }
                 else
                 {
-                    SpecificConfigId =  value.SpecificConfigId;
+                    SpecificConfigId = value.SpecificConfigId;
                 }
 
                 // reset unknown flag

--- a/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/DeviceConfiguration.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/DeviceConfiguration.cs
@@ -145,12 +145,12 @@ namespace nanoFramework.Tools.Debugger
         {
             try
             {
-                var addressAsArray = address.ToString().Split(new string[] { ":", "::" }, StringSplitOptions.RemoveEmptyEntries);
+                var addressBytesReversed = address.GetAddressBytes().Reverse().ToArray();
 
-                return new uint[] { uint.Parse(addressAsArray[3], NumberStyles.HexNumber),
-                                    uint.Parse(addressAsArray[2], NumberStyles.HexNumber),
-                                    uint.Parse(addressAsArray[1], NumberStyles.HexNumber),
-                                    uint.Parse(addressAsArray[0], NumberStyles.HexNumber) };
+                return new uint[] { BitConverter.ToUInt32(addressBytesReversed, 0),
+                                    BitConverter.ToUInt32(addressBytesReversed, 4),
+                                    BitConverter.ToUInt32(addressBytesReversed, 8),
+                                    BitConverter.ToUInt32(addressBytesReversed, 12) };
             }
             catch { };
 

--- a/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/NetworkConfigurationBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/NetworkConfigurationBase.cs
@@ -93,6 +93,12 @@ namespace nanoFramework.Tools.Debugger
         {
             // need to init this here to match the expected size on the struct to be sent to the device
             Marker = new byte[4];
+
+            IPv6Address = new uint[] { 0, 0, 0, 0 };
+            IPv6NetMask = new uint[] { 0, 0, 0, 0 };
+            IPv6GatewayAddress = new uint[] { 0, 0, 0, 0 };
+            IPv6DNSAddress1 = new uint[] { 0, 0, 0, 0 };
+            IPv6DNSAddress2 = new uint[] { 0, 0, 0, 0 };
         }
     }
 }


### PR DESCRIPTION
## Description
- Byte arrays for IPv6 structs weren't being created in constructor.
- Serialization of IPv6 addresses wasn't correct.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
