### PR TITLE
Improve UpdateDeviceConfiguration

### DIFF
--- a/USB Test App WPF/MainWindow.xaml.cs
+++ b/USB Test App WPF/MainWindow.xaml.cs
@@ -864,58 +864,82 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 
                 var device = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex];
 
-                // get device info
-                var deviceConfig = device.DebugEngine.GetDeviceConfiguration(cts.Token);
+                //DeviceConfiguration deviceConfig;
 
-                // update new network configuration
-                DeviceConfiguration.NetworkConfigurationProperties newDeviceNetworkConfiguration = new DeviceConfiguration.NetworkConfigurationProperties
-                {
-                    MacAddress = new byte[] { 0, 0x80, 0xe1, 0x01, 0x35, 0x56 },
-                    InterfaceType = NetworkInterfaceType.Ethernet,
-                    StartupAddressMode = AddressMode.DHCP,
-
-                    IPv4DNSAddress1 = IPAddress.Parse("192.168.1.254"),
-                };
-
-                // write device configuration to device
-                //var returnValue = device.DebugEngine.UpdateDeviceConfiguration(newDeviceNetworkConfiguration, 0);
-
-                //// add new wireless 802.11 configuration
-                //DeviceConfiguration.Wireless80211ConfigurationProperties newWireless80211Configuration = new DeviceConfiguration.Wireless80211ConfigurationProperties()
+                //// get device info, if needed
+                //if (device.DebugEngine.ConfigBlockRequiresErase)
                 //{
-                //    Id = 44,
-                //    Ssid = "Nice_Ssid",
-                //    Password = "1234",
+                //    deviceConfig = device.DebugEngine.GetDeviceConfiguration(cts.Token);
+                //}
+
+                //// update new network configuration
+                //DeviceConfiguration.NetworkConfigurationProperties newDeviceNetworkConfiguration = new DeviceConfiguration.NetworkConfigurationProperties
+                //{
+                //    MacAddress = new byte[] { 0, 0x80, 0xe1, 0x01, 0x35, 0x56 },
+                //    InterfaceType = NetworkInterfaceType.Ethernet,
+                //    StartupAddressMode = AddressMode.DHCP,
+
+                //    IPv4DNSAddress1 = IPAddress.Parse("192.168.1.254"),
                 //};
 
-                //// write wireless configuration to device
-                //returnValue = device.DebugEngine.UpdateDeviceConfiguration(newWireless80211Configuration, 0);
+                //// write device configuration to device
+                //var returnValue = device.DebugEngine.UpdateDeviceConfiguration(newDeviceNetworkConfiguration, 0);
+
+                // add new wireless 802.11 configuration
+                DeviceConfiguration.Wireless80211ConfigurationProperties newWireless80211Configuration = new DeviceConfiguration.Wireless80211ConfigurationProperties()
+                {
+                    Id = 0,
+                    Ssid = "Nice_Ssid",
+                    Password = "1234",
+                    Authentication = AuthenticationType.WPA2,
+                    Encryption = EncryptionType.WPA2,
+                    Options = Wireless80211_ConfigurationOptions.AutoConnect
+                };
+
+                // write wireless configuration to device
+                var returnValue = device.DebugEngine.UpdateDeviceConfiguration(newWireless80211Configuration, 0);
 
                 // build a CA certificate bundle
                 DeviceConfiguration.X509CaRootBundleProperties newX509CertificateBundle = new DeviceConfiguration.X509CaRootBundleProperties();
 
-                // add CA root certificates
+                //// add CA root certificates
 
-                /////////////////////////////////////////////////////////
-                // BECAUSE WE ARE PARSING FROM A BASE64 encoded format //
-                // NEED TO ADD A TERMINATOR TO THE STRING              //
-                /////////////////////////////////////////////////////////
+                ///////////////////////////////////////////////////////////
+                //// BECAUSE WE ARE PARSING FROM A BASE64 encoded format //
+                //// NEED TO ADD A TERMINATOR TO THE STRING              //
+                ///////////////////////////////////////////////////////////
 
-                //string caRootBundle = baltimoreCACertificate + letsEncryptCACertificate + "\0";
+                ////string caRootBundle = baltimoreCACertificate + letsEncryptCACertificate + "\0";
 
-                //byte[] certificateRaw = Encoding.UTF8.GetBytes(caRootBundle);
+                ////byte[] certificateRaw = Encoding.UTF8.GetBytes(caRootBundle);
 
-                using (FileStream binFile = new FileStream(@"C:\Users\JoséSimões\Downloads\DigiCertGlobalRootCA.crt", FileMode.Open))
-                {
-                    newX509CertificateBundle.Certificate = new byte[binFile.Length];
-                    binFile.Read(newX509CertificateBundle.Certificate, 0, (int)binFile.Length);
-                    newX509CertificateBundle.CertificateSize = (uint)binFile.Length;
-                }
+                //using (FileStream binFile = new FileStream(@"C:\Users\JoséSimões\Downloads\DigiCertGlobalRootCA.crt", FileMode.Open))
+                //{
+                //    newX509CertificateBundle.Certificate = new byte[binFile.Length];
+                //    binFile.Read(newX509CertificateBundle.Certificate, 0, (int)binFile.Length);
+                //    newX509CertificateBundle.CertificateSize = (uint)binFile.Length;
+                //}
 
                 //newX509CertificateBundle.Certificate = certificateRaw;
 
                 // write CA certificate to device
-                var returnValue = device.DebugEngine.UpdateDeviceConfiguration(newX509CertificateBundle, 0);
+                //var returnValue = device.DebugEngine.UpdateDeviceConfiguration(newX509CertificateBundle, 0);
+
+
+                //// build a device certificate 
+                //DeviceConfiguration.X509DeviceCertificatesProperties newX509DeviceCertificate = new DeviceConfiguration.X509DeviceCertificatesProperties();
+
+                //using (FileStream binFile = new FileStream(@"C:\Users\JoséSimões\Downloads\OilLevelCert.pfx", FileMode.Open))
+                //{
+                //    newX509DeviceCertificate.Certificate = new byte[binFile.Length];
+                //    binFile.Read(newX509DeviceCertificate.Certificate, 0, (int)binFile.Length);
+                //    newX509DeviceCertificate.CertificateSize = (uint)binFile.Length;
+                //}
+
+                //// write certificate to device
+                //var returnValue = device.DebugEngine.UpdateDeviceConfiguration(newX509DeviceCertificate, 0);
+
+
 
                 Debug.WriteLine("");
                 Debug.WriteLine("");


### PR DESCRIPTION
## Description
- Method now returns an enum with detailed outcome of the operation.
- Add sanity checks to detect invalid base configuration in the target.
- Fix erase of configuration region (now erases all config blocks instead of just the 1st one).
- Add Sleep between operation and retries to give a break to WP processor.
- Rework code to return proper report of failure/success.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Test app.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
