### PR TITLE
Fix race condition in PortSerialManager

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/PortSerialManager.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/PortSerialManager.cs
@@ -31,6 +31,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
         // counter of device watchers completed
         private int _newDevicesCount = 0;
+        private readonly object _newDevicesCountLock = new object();
 
         private readonly Random _delay = new Random(DateTime.Now.Millisecond);
 
@@ -277,7 +278,11 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                     }
 
                     // subtract devices count
-                    _newDevicesCount--;
+                    lock (_newDevicesCountLock)
+                    {
+                        _newDevicesCount--;
+                    }
+
 
                     // check if we are done processing arriving devices
                     if (_newDevicesCount == 0)
@@ -427,7 +432,10 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
             OnLogMessageAvailable(NanoDevicesEventSource.Log.DeviceArrival(serialPort));
 
-            _newDevicesCount++;
+            lock (_newDevicesCountLock)
+            {
+                _newDevicesCount++;
+            }
 
             Task.Run(() =>
             {


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
- Added lock, that guards increment and decrement of `_newDevicesCount`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Fixes nanoFramework/Home#1017

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
