### PR TITLE
Add support for flash alignment of 128 and 256 bits

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/Extensions/FlashSectorDataExtensions.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/Extensions/FlashSectorDataExtensions.cs
@@ -40,7 +40,7 @@ namespace nanoFramework.Tools.Debugger.Extensions
                 }
                 if( countOfBitsSet > 1)
                 {
-                    throw new Exception("Exception");
+                    throw new NotSupportedException("Multiple selections for Flash Program Width found, only one supported per block");
                 }
 
                 switch (blockRegionFlashProgrammingWidth)

--- a/nanoFramework.Tools.DebugLibrary.Shared/Extensions/FlashSectorDataExtensions.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/Extensions/FlashSectorDataExtensions.cs
@@ -45,19 +45,25 @@ namespace nanoFramework.Tools.Debugger.Extensions
 
                 switch (blockRegionFlashProgrammingWidth)
                 {
+                    case BlockRegionAttribute_ProgramWidthIs8bits:
+                        // when not specified, default to minimum flash word size
+                        programmingAlignment = 0;
+                        break;
+
                     case BlockRegionAttribute_ProgramWidthIs64bits:
                         programmingAlignment = 64 / 8;
                         break;
+
                     case BlockRegionAttribute_ProgramWidthIs128bits:
                         programmingAlignment = 128 / 8;
                         break;
+
                     case BlockRegionAttribute_ProgramWidthIs256bits:
                         programmingAlignment = 256 / 8;
                         break;
+
                     default:
-                        // No minimum flash word size
-                        programmingAlignment = 0;
-                        break;
+                        throw new NotSupportedException($"The specified Flash Program Width '{blockRegionFlashProgrammingWidth}' is not supported. Please check the native implementation and/or that you have the .NET nanoFramework Visual Studio extension update.");
                 }
 
                 Console.WriteLine($"The value is {programmingAlignment}");

--- a/nanoFramework.Tools.DebugLibrary.Shared/Extensions/FlashSectorDataExtensions.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/Extensions/FlashSectorDataExtensions.cs
@@ -27,12 +27,21 @@ namespace nanoFramework.Tools.Debugger.Extensions
                 int programmingAlignment = 0;
 
                 // check alignment requirements
-                if ((value.Flags
-                     & BlockRegionAttributes_MASK
-                     & BlockRegionAttribute_ProgramWidthIs64bits) == BlockRegionAttribute_ProgramWidthIs64bits)
+                uint blockRegionAttributes = value.Flags & BlockRegionAttributes_MASK;
+                switch (blockRegionAttributes)
                 {
-                    // programming width is 64bits => 8 bytes
-                    programmingAlignment = 8;
+                    case BlockRegionAttribute_ProgramWidthIs64bits:
+                        programmingAlignment = 64 / 8;
+                        break;
+                    case BlockRegionAttribute_ProgramWidthIs128bits:
+                        programmingAlignment = 128 / 8;
+                        break;
+                    case BlockRegionAttribute_ProgramWidthIs256bits:
+                        programmingAlignment = 256 / 8;
+                        break;
+                    default:
+                        programmingAlignment = 0;
+                        break;
                 }
 
                 blocks.Add(new DeploymentBlock(

--- a/nanoFramework.Tools.DebugLibrary.Shared/Extensions/FlashSectorDataExtensions.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/Extensions/FlashSectorDataExtensions.cs
@@ -27,21 +27,26 @@ namespace nanoFramework.Tools.Debugger.Extensions
                 int programmingAlignment = 0;
 
                 // check alignment requirements
-                uint blockRegionAttributes = value.Flags & BlockRegionAttributes_MASK;
-                switch (blockRegionAttributes)
+                if ((value.Flags
+                    & BlockRegionAttributes_MASK
+                    & BlockRegionAttribute_ProgramWidthIs64bits) == BlockRegionAttribute_ProgramWidthIs64bits)
                 {
-                    case BlockRegionAttribute_ProgramWidthIs64bits:
-                        programmingAlignment = 64 / 8;
-                        break;
-                    case BlockRegionAttribute_ProgramWidthIs128bits:
-                        programmingAlignment = 128 / 8;
-                        break;
-                    case BlockRegionAttribute_ProgramWidthIs256bits:
-                        programmingAlignment = 256 / 8;
-                        break;
-                    default:
-                        programmingAlignment = 0;
-                        break;
+                    // programming width is 64bits => 8 bytes
+                    programmingAlignment = 8;
+                }
+                if ((value.Flags
+                    & BlockRegionAttributes_MASK
+                    & BlockRegionAttribute_ProgramWidthIs128bits) == BlockRegionAttribute_ProgramWidthIs128bits)
+                {
+                    // programming width is 128bits => 16 bytes
+                    programmingAlignment = 16;
+                }
+                if ((value.Flags
+                    & BlockRegionAttributes_MASK
+                    & BlockRegionAttribute_ProgramWidthIs256bits) == BlockRegionAttribute_ProgramWidthIs256bits)
+                {
+                    // programming width is 256bits => 32 bytes
+                    programmingAlignment = 32;
                 }
 
                 blocks.Add(new DeploymentBlock(

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -96,6 +96,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
             // media attributes
             public const uint BlockRegionAttributes_MASK = 0x0000FF00;
+            public const uint BlockRegionFlashProgrammingWidth_MASK = 0x00000E00;
 
             public const uint BlockRegionAttribute_MemoryMapped = 0x0100;
 

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -101,6 +101,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             public const uint BlockRegionAttribute_MemoryMapped = 0x0100;
 
             // Programming width definitions
+            public const uint BlockRegionAttribute_ProgramWidthIs8bits = 0x0000;
             public const uint BlockRegionAttribute_ProgramWidthIs64bits = 0x0200;
             public const uint BlockRegionAttribute_ProgramWidthIs128bits = 0x0400;
             public const uint BlockRegionAttribute_ProgramWidthIs256bits = 0x0800;

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -98,8 +98,11 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             public const uint BlockRegionAttributes_MASK = 0x0000FF00;
 
             public const uint BlockRegionAttribute_MemoryMapped = 0x0100;
-            // programming width is 64bits
+
+            // Programming width definitions
             public const uint BlockRegionAttribute_ProgramWidthIs64bits = 0x0200;
+            public const uint BlockRegionAttribute_ProgramWidthIs128bits = 0x0400;
+            public const uint BlockRegionAttribute_ProgramWidthIs256bits = 0x0800;
 
             public struct FlashSectorData
             {


### PR DESCRIPTION
## Description
Based on the bit flags set in the BlockRegionAttribute, send data to be flashed as a multiple of 1,8,128 or 256 bits.
Previously only 1 and 8 were supported.


## Motivation and Context
To support STM32H7 series that have 128 and 256 bit minimum flash word writes.
- Corresponding flags added in native code: nanoframework/nf-interpreter#2405

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested on STM32H735g-DK development board for 256 bits.
1, and 8 bit words should remain unaffected.


## Screenshots
None

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
