### PR TITLE
Add support for more program widths

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/Extensions/FlashSectorDataExtensions.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/Extensions/FlashSectorDataExtensions.cs
@@ -62,6 +62,18 @@ namespace nanoFramework.Tools.Debugger.Extensions
                         programmingAlignment = 256 / 8;
                         break;
 
+                    case BlockRegionAttribute_ProgramWidthIs512bits:
+                        programmingAlignment = 512 / 8;
+                        break;
+
+                    case BlockRegionAttribute_ProgramWidthIs1024bits:
+                        programmingAlignment = 1024 / 8;
+                        break;
+
+                    case BlockRegionAttribute_ProgramWidthIs2048bits:
+                        programmingAlignment = 2048 / 8;
+                        break;
+
                     default:
                         throw new NotSupportedException($"The specified Flash Program Width '{blockRegionFlashProgrammingWidth}' is not supported. Please check the native implementation and/or that you have the .NET nanoFramework Visual Studio extension update.");
                 }

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -105,6 +105,9 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             public const uint BlockRegionAttribute_ProgramWidthIs64bits = 0x0200;
             public const uint BlockRegionAttribute_ProgramWidthIs128bits = 0x0400;
             public const uint BlockRegionAttribute_ProgramWidthIs256bits = 0x0800;
+            public const uint BlockRegionAttribute_ProgramWidthIs512bits = 0x1000;
+            public const uint BlockRegionAttribute_ProgramWidthIs1024bits = 0x2000;
+            public const uint BlockRegionAttribute_ProgramWidthIs2048bits = 0x4000;
 
             public struct FlashSectorData
             {

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -96,7 +96,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
 
             // media attributes
             public const uint BlockRegionAttributes_MASK = 0x0000FF00;
-            public const uint BlockRegionFlashProgrammingWidth_MASK = 0x00000E00;
+            public const uint BlockRegionFlashProgrammingWidth_MASK = 0x00007E00;
 
             public const uint BlockRegionAttribute_MemoryMapped = 0x0100;
 


### PR DESCRIPTION
## Description
- Support for large flash minimum programming sizes ( e.g. Raspberry PI PICO RP2040, 2048 bits)
- Also added 512,1024 bits for future use maintaining the bit pattern.

## Motivation and Context
- Following nanoframework/nf-interpreter#2505.
- Required for RP2040 

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Working on PICO

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [X] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
