### PR TITLE
Excluding Bluetooth serial ports from the list on Mac OS

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/DeviceWatcher.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/DeviceWatcher.cs
@@ -153,6 +153,12 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
             foreach (string name in Directory.GetFiles("/dev", "tty.usbserial*"))
             {
+                // We don't want Bluetooth ports
+                if (name.ToLower().Contains("bluetooth"))
+                {
+                    continue;
+                }
+
                 // GetFiles can return unexpected results because of 8.3 matching.
                 // Like /dev/tty
                 if (name.StartsWith("/dev/tty.", StringComparison.Ordinal))
@@ -163,6 +169,12 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
             foreach (string name in Directory.GetFiles("/dev", "cu.usbserial*"))
             {
+                // We don't want Bluetooth ports
+                if (name.ToLower().Contains("bluetooth"))
+                {
+                    continue;
+                }
+
                 if (name.StartsWith("/dev/cu.", StringComparison.Ordinal))
                 {
                     ports.Add(name);


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
Excluding Bluetooth serial ports from the list on Mac OS. Once open, Bluetooth ports do not properly time out and the code is blocked on device detection. Creates issues with other regular ports once open as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Should drastically improve device detection on Mac OS

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Need deeper tests with deployer.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
