### PR TITLE
Fixing serial read on M1 and when only partial data is available

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/PortSerial.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/PortSerial.cs
@@ -200,7 +200,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                 {
                     OnLogMessageAvailable(NanoDevicesEventSource.Log.OpenDevice(InstanceId));
                 }
-                else 
+                else
                 {
                     // Most likely the device is opened by another app, but cannot be sure
                     OnLogMessageAvailable(NanoDevicesEventSource.Log.CriticalError($"Can't open Device: {InstanceId}"));
@@ -336,7 +336,7 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                     // this loop shall fix issues with M1 and some drivers showing up bytes to fast
                     List<byte> received = new List<byte>();
                     int readBytes = 0;
-                    while (Device.BytesToRead > 0)
+                    while (Device.BytesToRead > 0 && readBytes < bytesToRead)
                     {
                         byte[] toRead = new byte[Device.BytesToRead];
                         readBytes += Device.Read(toRead, 0, toRead.Length);

--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/PortSerial.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/PortSerial.cs
@@ -336,19 +336,32 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                     // this loop shall fix issues with M1 and some drivers showing up bytes to fast
                     List<byte> received = new List<byte>();
                     int readBytes = 0;
+
                     while (Device.BytesToRead > 0 && readBytes < bytesToRead)
                     {
-                        byte[] toRead = new byte[Device.BytesToRead];
+                        // compute how many bytes shall be read from the device
+                        // so that we don't read more than what was requested
+                        int missingBytes = Math.Min(Device.BytesToRead, bytesToRead - readBytes);
+
+                        byte[] toRead = new byte[missingBytes];
+
+                        // read them
                         readBytes += Device.Read(toRead, 0, toRead.Length);
+
+                        // add to buffer
                         received.AddRange(toRead);
                     }
 
+                    // resize read buffer, if needed
                     if (readBytes != bytesToRead)
                     {
                         Array.Resize(ref buffer, readBytes);
                     }
 
+                    // copy over to read buffer
                     received.CopyTo(buffer);
+
+                    // done here
                     return buffer;
                 }
                 catch (TimeoutException)

--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/PortSerial.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/PortSerial.cs
@@ -333,13 +333,22 @@ namespace nanoFramework.Tools.Debugger.PortSerial
 
                 try
                 {
-                    int readBytes = Device.Read(buffer, 0, bytesToRead);
+                    // this loop shall fix issues with M1 and some drivers showing up bytes to fast
+                    List<byte> received = new List<byte>();
+                    int readBytes = 0;
+                    while (Device.BytesToRead > 0)
+                    {
+                        byte[] toRead = new byte[Device.BytesToRead];
+                        readBytes += Device.Read(toRead, 0, toRead.Length);
+                        received.AddRange(toRead);
+                    }
 
                     if (readBytes != bytesToRead)
                     {
                         Array.Resize(ref buffer, readBytes);
                     }
 
+                    received.CopyTo(buffer);
                     return buffer;
                 }
                 catch (TimeoutException)


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
Fixing serial read on M1 and when partial read is provided only

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- This should fix the issue in most cases of data ready to read provided before all the data are avaialbe. this will now read up to the point there is no more data available.
- This was mainly happening on M1 and it also depends of the quality of the drivers

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
