### PR TITLE
Add new constructors to PortBase

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Net/PortDefinitions/PortBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Net/PortDefinitions/PortBase.cs
@@ -10,8 +10,12 @@ using System.Collections.Generic;
 
 namespace nanoFramework.Tools.Debugger
 {
+    //  write intellisense documentation for this class  
     public abstract partial class PortBase : PortMessageBase
     {
+
+        #region creating serial instances
+
         public static PortBase CreateInstanceForSerial()
         {
             return new PortSerialManager(true, null);
@@ -19,32 +23,65 @@ namespace nanoFramework.Tools.Debugger
 
         public static PortBase CreateInstanceForSerial(List<string> portExclusionList)
         {
-            return new PortSerialManager(true, portExclusionList);
+            return new PortSerialManager(
+                true,
+                portExclusionList);
+        }
+        public static PortBase CreateInstanceForSerial(bool startDeviceWatchers)
+        {
+            return new PortSerialManager(
+                startDeviceWatchers,
+                null);
         }
 
-        public static PortBase CreateInstanceForSerial(bool startDeviceWatchers, int bootTime = 1000)
+        public static PortBase CreateInstanceForSerial(
+            bool startDeviceWatchers,
+            int bootTime = 1000)
         {
-            return new PortSerialManager(startDeviceWatchers, null, bootTime);
+            return new PortSerialManager(
+                startDeviceWatchers,
+                null,
+                bootTime);
         }
 
-        public static PortBase CreateInstanceForSerial(bool startDeviceWatchers, List<string> portExclusionList = null, int bootTime = 1000)
+        public static PortBase CreateInstanceForSerial(
+            bool startDeviceWatchers,
+            List<string> portExclusionList = null,
+            int bootTime = 1000)
         {
-            return new PortSerialManager(startDeviceWatchers, portExclusionList, bootTime);
+            return new PortSerialManager(
+                startDeviceWatchers,
+                portExclusionList,
+                bootTime);
         }
+
+        #endregion
+
+        #region creating tcp/ip instances
 
         public static PortBase CreateInstanceForNetwork(bool startDeviceWatchers)
         {
             return new PortTcpIpManager(startDeviceWatchers);
         }
 
-        public static PortBase CreateInstanceForNetwork(bool startDeviceWatchers, int discoveryPort)
+        public static PortBase CreateInstanceForNetwork(
+            bool startDeviceWatchers,
+            int discoveryPort)
         {
-            return new PortTcpIpManager(startDeviceWatchers, discoveryPort);
+            return new PortTcpIpManager(
+                startDeviceWatchers,
+                discoveryPort);
         }
 
-        public static PortBase CreateInstanceForComposite(IEnumerable<PortBase> ports, bool startDeviceWatchers)
+        #endregion
+
+        public static PortBase CreateInstanceForComposite(
+            IEnumerable<PortBase> ports,
+            bool startDeviceWatchers)
         {
-            return new PortCompositeDeviceManager(ports, startDeviceWatchers);
+            return new PortCompositeDeviceManager(
+                ports,
+                startDeviceWatchers);
         }
     }
 }


### PR DESCRIPTION
## Description
- Add new constructors to PortBase.
- Tidy up code following code style.

## Motivation and Context
- Need to have some simple constructor options.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
