### PR TITLE
Remove data annotations from several enums

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
+++ b/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj
@@ -66,14 +66,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub">
       <Version>1.1.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.5.119</Version>
+      <Version>3.6.132</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/Wireless80211ConfigurationPropertiesBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/Wireless80211ConfigurationPropertiesBase.cs
@@ -4,21 +4,50 @@
 //
 
 using PropertyChanged;
-using System.ComponentModel.DataAnnotations;
 
 namespace nanoFramework.Tools.Debugger
 {
+    /// <summary>
+    /// Base class for wireless 802.11 configuration properties.
+    /// </summary>
     [AddINotifyPropertyChangedInterface]
     public class Wireless80211ConfigurationPropertiesBase
     {
+        /// <summary>
+        /// Id of the configuration.
+        /// </summary>
         public uint Id { get; set; }
+
+        /// <summary>
+        /// Authentication type for the network.
+        /// </summary>
         public AuthenticationType Authentication { get; set; }
+
+        /// <summary>
+        /// Encryption type for the network.
+        /// </summary>
         public EncryptionType Encryption { get; set; }
+
+        /// <summary>
+        /// Radio type for the network.
+        /// </summary>
         public RadioType Radio { get; set; }
-        [MaxLength(32, ErrorMessage = "Maximum allowed length for SSID is 32.")]
+
+        /// <summary>
+        /// SSID of the network.
+        /// </summary>
+        /// <remarks>Maximum allowed length for network password is 32.</remarks>
         public string Ssid { get; set; }
-        [MaxLength(64, ErrorMessage = "Maximum allowed length for network password is 64.")]
+
+        /// <summary>
+        /// Password for the network.
+        /// </summary>
+        /// <remarks>Maximum allowed length for network password is 64</remarks>
         public string Password { get; set; }
+
+        /// <summary>
+        /// Configuration options for the network.
+        /// </summary>
         public Wireless80211_ConfigurationOptions Options { get; set; }
     }
 }

--- a/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/WirelessAPConfigurationPropertiesBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/DeviceConfiguration/WirelessAPConfigurationPropertiesBase.cs
@@ -4,23 +4,60 @@
 //
 
 using PropertyChanged;
-using System.ComponentModel.DataAnnotations;
 
 namespace nanoFramework.Tools.Debugger
 {
+    /// <summary>
+    /// Base class for wireless Access Poing configuration properties.
+    /// </summary>
     [AddINotifyPropertyChangedInterface]
     public class WirelessAPConfigurationPropertiesBase
     {
+        /// <summary>
+        /// Id of the configuration.
+        /// </summary>
         public uint Id { get; set; }
+
+        /// <summary>
+        /// Authentication type for the network.
+        /// </summary>
         public AuthenticationType Authentication { get; set; }
+
+        /// <summary>
+        /// Encryption type for the network.
+        /// </summary>
         public EncryptionType Encryption { get; set; }
+
+        /// <summary>
+        /// Radio type for the network.
+        /// </summary>
         public RadioType Radio { get; set; }
-        [MaxLength(32, ErrorMessage = "Maximum allowed length for SSID is 32.")]
+
+        /// <summary>
+        /// SSID of the network.
+        /// </summary>
+        /// <remarks>Maximum allowed length for network password is 32.</remarks>
         public string Ssid { get; set; }
-        [MaxLength(64, ErrorMessage = "Maximum allowed length for network password is 64.")]
+
+        /// <summary>
+        /// Password for the network.
+        /// </summary>
+        /// <remarks>Maximum allowed length for network password is 64</remarks>
         public string Password { get; set; }
+
+        /// <summary>
+        /// Configuration options for the network.
+        /// </summary>
         public WirelessAP_ConfigurationOptions Options { get; set; }
+
+        /// <summary>
+        /// Channel for the network.
+        /// </summary>
         public byte Channel { get; set; }
+
+        /// <summary>
+        /// Maximum number of connections allowed.
+        /// </summary>
         public byte MaxConnections { get; set; }
     }
 }

--- a/nanoFramework.Tools.DebugLibrary.Shared/NetworkInformation/AuthenticationType.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NetworkInformation/AuthenticationType.cs
@@ -4,7 +4,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System.ComponentModel.DataAnnotations;
+using System.ComponentModel;
 
 namespace nanoFramework.Tools.Debugger
 {
@@ -12,18 +12,21 @@ namespace nanoFramework.Tools.Debugger
     // !!! KEEP IN SYNC WITH System.Net.NetworkInformation.AuthenticationType (in nanoFramework.System.Net) !!! //
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+    /// <summary>
+    /// Specifies the authentication type used for joining a Wi-Fi network.
+    /// </summary>
     public enum AuthenticationType : byte
     {
         /// <summary>
         /// No protocol.
         /// </summary>
         None = 0,
-        
+
         /// <summary>
         /// Extensible Authentication Protocol.
         /// </summary>
         EAP,
-        
+
         /// <summary>
         /// Protected Extensible Authentication Protocol.
         /// </summary>
@@ -37,31 +40,31 @@ namespace nanoFramework.Tools.Debugger
         /// <summary>
         /// Open System authentication, for use with WEP encryption type.
         /// </summary>
-        [Display(Description = "WEP Open")]
+        [Description("WEP Open")]
         Open,
 
         /// <summary>
         /// Shared Key authentication, for use with WEP encryption type.
         /// </summary>
-        [Display(Description = "WEP Shared")]
+        [Description("WEP Shared")]
         Shared,
 
         /// <summary>
         /// Wired Equivalent Privacy protocol.
         /// </summary>
-        [Display(Description = "WEP")]
+        [Description("WEP")]
         WEP,
 
         /// <summary>
         /// Wi-Fi Protected Access protocol.
         /// </summary>
-        [Display(Description = "WPA")]
+        [Description("WPA")]
         WPA,
 
         /// <summary>
         /// Wi-Fi Protected Access 2 protocol.
         /// </summary>
-        [Display(Description = "WPA2")]
+        [Description("WPA2")]
         WPA2,
     }
 }

--- a/nanoFramework.Tools.DebugLibrary.Shared/NetworkInformation/EncryptionType.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NetworkInformation/EncryptionType.cs
@@ -4,55 +4,59 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System.ComponentModel.DataAnnotations;
+using System.ComponentModel;
 
 namespace nanoFramework.Tools.Debugger
 {
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
     // !!! KEEP IN SYNC WITH System.Net.NetworkInformation.EncryptionType (in nanoFramework.System.Net) !!! //
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /// <summary>
+    /// Encryption type for the Wireless network interface.
+    /// </summary>
     public enum EncryptionType : byte
     {
         /// <summary>
         /// No encryption.
         /// </summary>
-        [Display(Description = "")]
+        [Description("")]
         None = 0,
 
         /// <summary>
         /// Wired Equivalent Privacy encryption.
         /// </summary>
-        [Display(Description = "WEP")]
+        [Description("WEP")]
         WEP,
 
         /// <summary>
         /// Wireless Protected Access encryption.
         /// </summary>
-        [Display(Description = "WPA")]
+        [Description("WPA")]
         WPA,
 
         /// <summary>
         /// Wireless Protected Access 2 encryption.
         /// </summary>
-        [Display(Description = "WPA2")]
+        [Description("WPA2")]
         WPA2,
 
         /// <summary>
         /// Wireless Protected Access Pre-Shared Key encryption.
         /// </summary>
-        [Display(Description = "WPA Pre-Shared Key")]
+        [Description("WPA Pre-Shared Key")]
         WPA_PSK,
 
         /// <summary>
         /// Wireless Protected Access 2 Pre-Shared Key encryption.
         /// </summary>
-        [Display(Description = "WPA2 Pre-Shared Key")]
+        [Description("WPA2 Pre-Shared Key")]
         WPA2_PSK2,
 
         /// <summary>
         /// Certificate encryption.
         /// </summary>
-        [Display(Description = "Certificate")]
+        [Description("Certificate")]
         Certificate,
     }
 }

--- a/nanoFramework.Tools.DebugLibrary.Shared/NetworkInformation/NetworkInterfaceType.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NetworkInformation/NetworkInterfaceType.cs
@@ -4,30 +4,34 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System.ComponentModel.DataAnnotations;
+using System.ComponentModel;
 
 namespace nanoFramework.Tools.Debugger
 {
-    /////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // !!! KEEP IN SYNC WITH System.Net.NetworkInformation.NetworkInterfaceType (in nanoFramework.System.Net) !!! //
-    /////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    /// <summary>
+    /// Network interface type.
+    /// </summary>
     public enum NetworkInterfaceType : byte
     {
         /// <summary>
         /// The network interface type is unknown or not specified.
         /// </summary>
+        [Description("")]
         Unknown = 1,
 
         /// <summary>
         /// The network interface uses an Ethernet connection. Ethernet is defined in IEEE standard 802.3.
         /// </summary>
-        [Display(Description = "Ethernet")]
+        [Description("Ethernet")]
         Ethernet = 6,
 
         /// <summary>
         /// The network interface uses a wireless LAN connection (IEEE 802.11 standard).
         /// </summary>
-        [Display(Description = "Wi-Fi (802.11)")]
+        [Description("Wi-Fi (802.11)")]
         Wireless80211 = 71,
     }
 }

--- a/nanoFramework.Tools.DebugLibrary.Shared/NetworkInformation/RadioType.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NetworkInformation/RadioType.cs
@@ -4,37 +4,41 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System.ComponentModel.DataAnnotations;
+using System.ComponentModel;
 
 namespace nanoFramework.Tools.Debugger
 {
     /////////////////////////////////////////////////////////////////////////////////////////////////////
     // !!! KEEP IN SYNC WITH System.Net.NetworkInformation.RadioType (in nanoFramework.System.Net) !!! //
     /////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /// <summary>
+    /// Radio type for the Wireless network interface.
+    /// </summary>
     public enum RadioType : byte
     {
         /// <summary>
         /// 802.11a-compatible radio.
         /// </summary>
-        [Display(Description = "802.11a")]
+        [Description("802.11a")]
         _802_11a = 1,
 
         /// <summary>
         /// 802.11b-compatible radio.
         /// </summary>
-        [Display(Description = "802.11b")]
+        [Description("802.11b")]
         _802_11b = 2,
 
         /// <summary>
         /// 802.11g-compatible radio.
         /// </summary>
-        [Display(Description = "802.11g")]
+        [Description("802.11g")]
         _802_11g = 4,
 
         /// <summary>
         /// 802.11n-compatible radio.
         /// </summary>
-        [Display(Description = "802.11n")]
+        [Description("802.11n")]
         _802_11n = 8,
     }
 }

--- a/nanoFramework.Tools.DebugLibrary.Shared/NetworkInformation/Wireless80211_ConfigurationOptions.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NetworkInformation/Wireless80211_ConfigurationOptions.cs
@@ -4,13 +4,14 @@
 //
 
 using System;
-using System.ComponentModel.DataAnnotations;
+using System.ComponentModel;
 
 namespace nanoFramework.Tools.Debugger
 {
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // !!! KEEP IN SYNC WITH System.Net.NetworkInformation.Wireless80211Configuration.ConfigurationOptions (in nanoFramework.System.Net) !!! //
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
     /// <summary>
     /// Configuration flags used for Wireless configuration.
     /// </summary>
@@ -37,7 +38,7 @@ namespace nanoFramework.Tools.Debugger
         /// Will auto connect when AP is available or after being disconnected.
         /// This option forces enabling the Wireless station.
         /// </summary>
-        [Display(Description = "Auto connect")]
+        [Description("Auto connect")]
         AutoConnect = 0x04 | Enable,
 
         /// <summary>

--- a/nanoFramework.Tools.DebugLibrary.Shared/NetworkInformation/WirelessAP_ConfigurationOptions.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NetworkInformation/WirelessAP_ConfigurationOptions.cs
@@ -4,13 +4,14 @@
 //
 
 using System;
-using System.ComponentModel.DataAnnotations;
+using System.ComponentModel;
 
 namespace nanoFramework.Tools.Debugger
 {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // !!! KEEP IN SYNC WITH System.Net.NetworkInformation.WirelessAPConfiguration.ConfigurationOptions (in nanoFramework.System.Net) !!! //
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
     /// <summary>
     /// Configuration flags used for Wireless Soft AP configuration.
     /// </summary>
@@ -37,13 +38,13 @@ namespace nanoFramework.Tools.Debugger
         /// Will automatically start the Soft AP when CLR starts.
         /// This option forces enabling the Wireless Soft AP.
         /// </summary>
-        [Display(Description = "Auto start")]
+        [Description("Auto start")]
         AutoStart = 0x04 | Enable,
 
         /// <summary>
         /// The SSID for the Soft AP will be hidden.
         /// </summary>
-        [Display(Description = "SSID hidden")]
+        [Description("SSID hidden")]
         HiddenSSID = 0x08,
     };
 }


### PR DESCRIPTION
## Description
- Replace with DescriptionAttribute.
- Remove dependency of DataAnnotations.
- Add Intellisense comments to several enums.
- Update nbgv to 3.6.132.

## Motivation and Context
- Getting rid of troublesome library: DataAnnotations. 

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
