### PR TITLE
Add flag to disable stack trace crawling on exceptions

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -661,6 +661,16 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 DebuggerQuiet = 0x00010000,
 
                 /// <summary>
+                /// Execution engine won't process stack trace when an exception occurs.
+                /// </summary>
+                /// <remarks>
+                /// This is used to save processing time with crawling the stack and gatthering the details. It will also
+                /// prevent detailed stack trace information to be sent to the debugger. The StackTrace property in the Exception will be empty.
+                /// Note that this won't have any effect if the firmware has been compiled without debugger support or with the configuration that disables tracing exceptions.
+                /// </remarks>
+                NoStackTraceInExceptions = 0x02000000,
+
+                /// <summary>
                 /// Threads associated with timers are created in "suspended" mode.
                 /// </summary>
                 PauseTimers = 0x04000000,


### PR DESCRIPTION
## Description
- Add new enum to control this option.

## Motivation and Context
- Need to provide the option to disable detailed stack trace crawling and reporting. This allows more clean output during debug if the developer chooses to not see exception messages.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
