### PR TITLE
Add NoStackTraceInExceptions property to Engine

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -447,6 +447,11 @@ namespace nanoFramework.Tools.Debugger
                 // get state flags to set
                 Commands.DebuggingExecutionChangeConditions.State stateFlagsToSet = Commands.DebuggingExecutionChangeConditions.State.SourceLevelDebugging;
 
+                if (NoStackTraceInExceptions)
+                {
+                    stateFlagsToSet |= Commands.DebuggingExecutionChangeConditions.State.NoStackTraceInExceptions;
+                }
+
                 if (Silent)
                 {
                     stateFlagsToSet |= Commands.DebuggingExecutionChangeConditions.State.DebuggerQuiet;
@@ -962,6 +967,11 @@ namespace nanoFramework.Tools.Debugger
         }
 
         public bool IsRunning => _state.IsRunning;
+
+        /// <summary>
+        ///  
+        /// </summary>
+        public bool NoStackTraceInExceptions { get; set; }
 
         #region RPC Support
 


### PR DESCRIPTION
## Description
- Add NoStackTraceInExceptions property to Engine.
- UpdateDebugFlags now takes this property when setting execution mode.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
