### PR TITLE
Fix BitStream Buffer constructor

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/BitStream.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/BitStream.cs
@@ -35,13 +35,38 @@ namespace nanoFramework.Tools.Debugger
                 Array.Copy(data, pos, m_data, 0, len);
             }
 
-            internal Buffer(byte[] data, int pos, int len, int bitsInLastPos)
+            internal Buffer(
+                byte[] data,
+                int pos,
+                int len,
+                int bitsInLastPos)
             {
-                if (bitsInLastPos < 1 || bitsInLastPos > 8) { throw new ArgumentException("bits"); }
+                if (bitsInLastPos < 1 || bitsInLastPos > 8) 
+                { 
+                    throw new ArgumentException("bits");
+                }
+
                 m_data = new byte[len];
-                m_length = len;
                 m_avail = bitsInLastPos;
-                Array.Copy(data, pos, m_data, 0, len);
+
+                // can't copy more than what's available in the source array!
+                if (len > data.Length - pos)
+                {
+                    // NOT enough elements, so adjust length to copy
+                    m_length = data.Length - pos;
+                }
+                else
+                {
+                    // all good
+                    m_length = len;
+                }
+
+                Array.Copy(
+                    data,
+                    pos,
+                    m_data,
+                    0,
+                    m_length);
             }
         }
 


### PR DESCRIPTION
## Description
- Add check for source array length and adjusting if needed.

## Motivation and Context
- Processing partial packets were causing exceptions when trying to copy a full-length array despite there wasn't enough elements. 

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
