### PR TITLE
Add Storage Operation Command

### DIFF
--- a/USB Test App WPF/MainWindow.xaml
+++ b/USB Test App WPF/MainWindow.xaml
@@ -27,30 +27,32 @@
         <Button Content="Disconnect" HorizontalAlignment="Left" Margin="250,102,0,0" VerticalAlignment="Top" Width="98" Click="DisconnectDeviceButton_Click"/>
         <Button Content="Ping" HorizontalAlignment="Left" Margin="250,129,0,0" VerticalAlignment="Top" Width="98" Click="PingButton_Click" />
 
-        <Button Content="Get Execution" HorizontalAlignment="Left" Margin="250,195,0,0" VerticalAlignment="Top" Width="98" Click="GetExecutionModeButton_Click"/>
-        <Button Content="Deploy Test" HorizontalAlignment="Left" Margin="162,235,0,0" VerticalAlignment="Top" Width="75" Click="DeployTestButton_Click" />
-        <Button Content="Get Deployment Map" HorizontalAlignment="Left" Margin="162,275,0,0" VerticalAlignment="Top" Width="75" Click="GetDeploymentMapButton_Click" />
+        <Button Content="Get Execution" HorizontalAlignment="Left" Margin="250,187,0,0" VerticalAlignment="Top" Width="98" Click="GetExecutionModeButton_Click"/>
+        <Button Content="Deploy Test" HorizontalAlignment="Left" Margin="162,216,0,0" VerticalAlignment="Top" Width="75" Click="DeployTestButton_Click" />
+        <Button Content="Get Deployment Map" HorizontalAlignment="Left" Margin="162,245,0,0" VerticalAlignment="Top" Width="75" Click="GetDeploymentMapButton_Click" />
 
-        <Button Content="Device Capabilites" HorizontalAlignment="Left" Margin="39,195,0,0" VerticalAlignment="Top" Width="110" Click="DeviceCapabilitesButton_Click" />
-        <Button Content="Flash Map" HorizontalAlignment="Left" Margin="39,275,0,0" VerticalAlignment="Top" Width="110" Click="FlashMapButton_Click" />
-        <Button Content="Resolve Assemblies" HorizontalAlignment="Left" Margin="39,235,0,0" VerticalAlignment="Top" Width="110" Click="ResolveAssembliesButton_Click" />
+        <Button Content="Device Capabilites" HorizontalAlignment="Left" Margin="39,187,0,0" VerticalAlignment="Top" Width="110" Click="DeviceCapabilitesButton_Click" />
+        <Button Content="Flash Map" HorizontalAlignment="Left" Margin="39,245,0,0" VerticalAlignment="Top" Width="110" Click="FlashMapButton_Click" />
+        <Button Content="Resolve Assemblies" HorizontalAlignment="Left" Margin="39,216,0,0" VerticalAlignment="Top" Width="110" Click="ResolveAssembliesButton_Click" />
 
-        <Button Content="Pause Execution" HorizontalAlignment="Left" Margin="250,235,0,0" VerticalAlignment="Top" Width="98" Click="PauseExecutionButton_Click" />
-        <Button Content="Resume Execution" HorizontalAlignment="Left" Margin="250,275,0,0" VerticalAlignment="Top" Width="98" Click="ResumeExecutionButton_Click" />
+        <Button Content="Pause Execution" HorizontalAlignment="Left" Margin="250,216,0,0" VerticalAlignment="Top" Width="98" Click="PauseExecutionButton_Click" />
+        <Button Content="Resume Execution" HorizontalAlignment="Left" Margin="250,245,0,0" VerticalAlignment="Top" Width="98" Click="ResumeExecutionButton_Click" />
 
-        <Button Content="Reboot CLR" HorizontalAlignment="Left" Margin="378,77,0,0" VerticalAlignment="Top" Width="121" Click="RebootDeviceButton_Click"/>
-        <Button Content="Soft Reboot" HorizontalAlignment="Left" Margin="378,102,0,0" VerticalAlignment="Top" Width="121" Click="SoftRebootDeviceButton_Click"/>
-        <Button Content="Reboot to bootloader" HorizontalAlignment="Left" Margin="378,129,0,0" VerticalAlignment="Top" Width="121" Click="RebootToBootloaderButton_Click"/>
-        <Button Content="Stop Processing" HorizontalAlignment="Left" Margin="378,195,0,0" VerticalAlignment="Top" Width="121" Click="StopProcessingButton_Click"/>
-        <Button Content="Erase Deployment" HorizontalAlignment="Left" Margin="378,235,0,0" VerticalAlignment="Top" Width="121" Click="EraseDeploymentButton_Click" />
-        <Button Content="Is Init State" HorizontalAlignment="Left" Margin="162,195,0,0" VerticalAlignment="Top" Width="75" Click="IsInitStateButton_Click" />
-        <Button Content="Get Device Config" HorizontalAlignment="Left" Margin="378,275,0,0" VerticalAlignment="Top" Width="121" Click="GetDeviceConfigButton_Click" />
-        <Button Content="Set Device Config" HorizontalAlignment="Left" Margin="378,313,0,0" VerticalAlignment="Top" Width="121" Click="SetDeviceConfigButton_Click" />
+        <Button Content="Reboot CLR" HorizontalAlignment="Left" Margin="364,77,0,0" VerticalAlignment="Top" Width="121" Click="RebootDeviceButton_Click"/>
+        <Button Content="Soft Reboot" HorizontalAlignment="Left" Margin="364,102,0,0" VerticalAlignment="Top" Width="121" Click="SoftRebootDeviceButton_Click"/>
+        <Button Content="Reboot to bootloader" HorizontalAlignment="Left" Margin="364,129,0,0" VerticalAlignment="Top" Width="121" Click="RebootToBootloaderButton_Click"/>
+        <Button Content="Stop Processing" HorizontalAlignment="Left" Margin="364,187,0,0" VerticalAlignment="Top" Width="121" Click="StopProcessingButton_Click"/>
+        <Button Content="Erase Deployment" HorizontalAlignment="Left" Margin="364,216,0,0" VerticalAlignment="Top" Width="121" Click="EraseDeploymentButton_Click" />
+        <Button Content="Is Init State" HorizontalAlignment="Left" Margin="162,187,0,0" VerticalAlignment="Top" Width="75" Click="IsInitStateButton_Click" />
+        <Button Content="Get Device Config" HorizontalAlignment="Left" Margin="364,245,0,0" VerticalAlignment="Top" Width="121" Click="GetDeviceConfigButton_Click" />
+        <Button Content="Set Device Config" HorizontalAlignment="Left" Margin="364,275,0,0" VerticalAlignment="Top" Width="121" Click="SetDeviceConfigButton_Click" />
         <Button Content="ReScan devices" HorizontalAlignment="Left" Margin="250,157,0,0" VerticalAlignment="Top" Width="98" Click="ReScanDevices_Click" />
-        <Button Content="Read Test" HorizontalAlignment="Left" Margin="250,313,0,0" VerticalAlignment="Top" Width="98" Click="ReadTestButton_Click" />
-        <Button Content="Target Info" HorizontalAlignment="Left" Margin="39,313,0,0" VerticalAlignment="Top" Width="110" Click="TargetInfoButton_Click" />
-        <Button Content="Reboot to nanoBooter" HorizontalAlignment="Left" Margin="378,157,0,0" VerticalAlignment="Top" Width="121" Click="RebootToNanoBooterButton_Click"/>
-        <Button Content="Deploy File" HorizontalAlignment="Left" Margin="162,313,0,0" VerticalAlignment="Top" Width="75" Click="DeployFileTestButton_Click" />
+        <Button Content="Read Test" HorizontalAlignment="Left" Margin="250,275,0,0" VerticalAlignment="Top" Width="98" Click="ReadTestButton_Click" />
+        <Button Content="Target Info" HorizontalAlignment="Left" Margin="39,275,0,0" VerticalAlignment="Top" Width="110" Click="TargetInfoButton_Click" />
+        <Button Content="Reboot to nanoBooter" HorizontalAlignment="Left" Margin="364,157,0,0" VerticalAlignment="Top" Width="121" Click="RebootToNanoBooterButton_Click"/>
+        <Button Content="Deploy File" HorizontalAlignment="Left" Margin="162,275,0,0" VerticalAlignment="Top" Width="75" Click="DeployFileTestButton_Click" />
+        <Button Content="Reboot CLR" HorizontalAlignment="Left" Margin="364,77,0,0" VerticalAlignment="Top" Width="121" Click="RebootDeviceButton_Click"/>
+        <Button Content="Upload File I:\" HorizontalAlignment="Left" Margin="39,306,0,0" VerticalAlignment="Top" Width="110" Click="UploadFileInternalStorage_Click"/>
 
 
     </Grid>

--- a/USB Test App WPF/MainWindow.xaml
+++ b/USB Test App WPF/MainWindow.xaml
@@ -53,6 +53,7 @@
         <Button Content="Deploy File" HorizontalAlignment="Left" Margin="162,275,0,0" VerticalAlignment="Top" Width="75" Click="DeployFileTestButton_Click" />
         <Button Content="Reboot CLR" HorizontalAlignment="Left" Margin="364,77,0,0" VerticalAlignment="Top" Width="121" Click="RebootDeviceButton_Click"/>
         <Button Content="Upload File I:\" HorizontalAlignment="Left" Margin="39,306,0,0" VerticalAlignment="Top" Width="110" Click="UploadFileInternalStorage_Click"/>
+        <Button Content="Rm file I:\" HorizontalAlignment="Left" Margin="162,306,0,0" VerticalAlignment="Top" Width="75" Click="RemoveFileInternalStorage_Click"/>
 
 
     </Grid>

--- a/USB Test App WPF/MainWindow.xaml.cs
+++ b/USB Test App WPF/MainWindow.xaml.cs
@@ -1114,7 +1114,7 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
             // disable button
             (sender as Button).IsEnabled = false;
 
-            var reply1 = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.AddFile(fileName, Encoding.UTF8.GetBytes(fileContent));
+            var reply1 = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.AddStorageFile(fileName, Encoding.UTF8.GetBytes(fileContent));
             Debug.WriteLine($"File upload internal success: {reply1}");
 
             // enable button
@@ -1127,7 +1127,7 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
             // disable button
             (sender as Button).IsEnabled = false;
 
-            var reply1 = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.RemoveFile(fileName);
+            var reply1 = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.DeleteStorageFile(fileName);
             Debug.WriteLine($"File upload internal success: {reply1}");
 
             // enable button

--- a/USB Test App WPF/MainWindow.xaml.cs
+++ b/USB Test App WPF/MainWindow.xaml.cs
@@ -1095,21 +1095,39 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 
         private void UploadFileInternalStorage_Click(object sender, RoutedEventArgs e)
         {
-            string fileContent = "This is a test file to upload in internal storage. A long message to test more than just a line.\r\n" +
+            string fileContent = "1. This is a test file to upload in internal storage. A long message to test more than just a line.\r\n" +
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
                 "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. " +
                 "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. " +
-                "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\r\n" +
+                "2. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\r\n" +
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
                 "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. " +
                 "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. " +
-                "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+                "3. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\r\n" +
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
+                "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. " +
+                "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. " +
+                "4. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\r\n";
+            //string fileContent = "simple test file";
             string fileName = "I:\\upload.txt";
 
             // disable button
             (sender as Button).IsEnabled = false;
 
             var reply1 = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.AddFile(fileName, Encoding.UTF8.GetBytes(fileContent));
+            Debug.WriteLine($"File upload internal success: {reply1}");
+
+            // enable button
+            (sender as Button).IsEnabled = true;
+        }
+
+        private void RemoveFileInternalStorage_Click(object sender, RoutedEventArgs e)
+        {
+            string fileName = "I:\\upload.txt";
+            // disable button
+            (sender as Button).IsEnabled = false;
+
+            var reply1 = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.RemoveFile(fileName);
             Debug.WriteLine($"File upload internal success: {reply1}");
 
             // enable button

--- a/USB Test App WPF/MainWindow.xaml.cs
+++ b/USB Test App WPF/MainWindow.xaml.cs
@@ -1092,5 +1092,28 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
             // enable button
             (sender as Button).IsEnabled = true;
         }
+
+        private void UploadFileInternalStorage_Click(object sender, RoutedEventArgs e)
+        {
+            string fileContent = "This is a test file to upload in internal storage. A long message to test more than just a line.\r\n" +
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
+                "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. " +
+                "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. " +
+                "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\r\n" +
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
+                "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. " +
+                "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. " +
+                "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+            string fileName = "I:\\upload.txt";
+
+            // disable button
+            (sender as Button).IsEnabled = false;
+
+            var reply1 = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.AddFile(fileName, Encoding.UTF8.GetBytes(fileContent));
+            Debug.WriteLine($"File upload internal success: {reply1}");
+
+            // enable button
+            (sender as Button).IsEnabled = true;
+        }
     }
 }

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -557,10 +557,10 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         /// </summary>
         public class Monitor_StorageOperation : OverheadBase
         {
-            public StorageOperation Operation = StorageOperation.None;
-            public uint Length = 0;
-            public string StorageName = null;
-            public byte[] Data = null;
+            public uint Operation = (byte)StorageOperation.None;
+            public uint NameLength = 0;
+            public uint DataLength = 0;
+            public byte[] Data = new byte[0];
 
             public class Reply
             {
@@ -571,8 +571,9 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
               StorageOperation operation,
               string name)
             {
-                Operation = operation;
-                StorageName = name;
+                Operation = (byte)operation;
+                Data = Encoding.UTF8.GetBytes(name);
+                NameLength = (uint)Data.Length;
             }
 
             public void PrepareForSend(
@@ -582,8 +583,9 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 int offset,
                 int length)
             {
-                Operation = operation;
-                StorageName = name;
+                Operation = (byte)operation;
+                Data = Encoding.UTF8.GetBytes(name);
+                NameLength = (uint)(Data.Length + data.Length);
 
                 PrepareForSend(data, offset, length);
             }
@@ -593,10 +595,16 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 int offset,
                 int length)
             {
-                Length = (uint)length;
-                Data = new byte[length];
+                DataLength = (uint)length;
+                if(Data.Length < DataLength + NameLength)
+                {
+                    byte[] bytes = new byte[Data.Length];
+                    Array.Copy(Data, 0, bytes, 0, Data.Length);
+                    Data = new byte[DataLength + NameLength];
+                    Array.Copy(bytes, 0, Data, 0, bytes.Length);
+                }
 
-                Array.Copy(data, offset, Data, 0, length);
+                Array.Copy(data, offset, Data, NameLength, length);
 
                 return true;
             }
@@ -629,88 +637,15 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 /// <remarks>
                 /// If the file doesn't exist, no action is taken.
                 /// </remarks>
-                Delete = 2
-            }
-        }
-
-        /// <summary>
-        /// Perform storage operation on the target device.
-        /// </summary>
-        public class Monitor_StorageOperation : OverheadBase
-        {
-            public StorageOperation Operation = StorageOperation.None;
-            public string StorageName = string.Empty;
-            public uint Length = 0;
-            public byte[] Data = null;
-
-            public class Reply
-            {
-                public uint ErrorCode;
-            };
-
-            public void PrepareForSend(
-              StorageOperation operation,
-              string name)
-            {
-                Operation = operation;
-                StorageName = name;
-            }
-
-            public void PrepareForSend(
-                StorageOperation operation,
-                string name,
-                byte[] data,
-                int offset,
-                int length)
-            {
-                Operation = operation;
-                StorageName = name;
-
-                PrepareForSend(data, offset, length);
-            }
-
-            public override bool PrepareForSend(
-                byte[] data,
-                int offset,
-                int length)
-            {
-                Length = (uint)length;
-                Data = new byte[length];
-
-                Array.Copy(data, offset, Data, 0, length);
-
-                return true;
-            }
-
-            //////////////////////////////////////////////////////////////////////////////////////
-            // !!! KEEP IN SYNC WITH typedef enum Monitor_StorageOperation (in native code) !!! //
-            //////////////////////////////////////////////////////////////////////////////////////
-
-            /// <summary>
-            /// Storage operation to be performed.
-            /// </summary>
-            public enum StorageOperation : byte
-            {
-                /// <summary>
-                /// Not specified.
-                /// </summary>
-                None = 0,
+                Delete = 2,
 
                 /// <summary>
-                /// Write to storage.
-                /// </summary>
-                /// <remarks>
-                /// If the file already exists, it will be overwritten.
-                /// </remarks>
-                Write = 1,
-
-                /// <summary>
-                /// Delete from storage.
+                /// Append to a file.
                 /// </summary>
                 /// <remarks>
                 /// If the file doesn't exist, no action is taken.
                 /// </remarks>
-                Delete = 2
+                Append = 3
             }
         }
 

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -593,7 +593,12 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 public uint ErrorCode;
             };
 
-            public void PrepareForSend(
+            /// <summary>
+            /// Prepare for sending a storage operation to the target device.
+            /// </summary>
+            /// <param name="operation"><see cref="StorageOperation"/> to be performed.</param>
+            /// <param name="name">Name of the file to be used in the operation.</param>
+            public void SetupOperation(
               StorageOperation operation,
               string name)
             {
@@ -602,35 +607,25 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 NameLength = (uint)Data.Length;
             }
 
-            public void PrepareForSend(
-                StorageOperation operation,
-                string name,
-                byte[] data,
-                int offset,
-                int length)
-            {
-                Operation = (byte)operation;
-                Data = Encoding.UTF8.GetBytes(name);
-                NameLength = (uint)(Data.Length + data.Length);
-
-                PrepareForSend(data, offset, length);
-            }
-
+            /// <summary>
+            /// Prepare for sending a storage operation to the target device.
+            /// </summary>
+            /// <param name="buffer">Data buffer to be sent to the device.</param>
+            /// <param name="offset">Offset in the <paramref name="buffer"/> to start copying data from.</param>
+            /// <param name="length">Length of the data to be copied from the <paramref name="buffer"/>.</param>
             public override bool PrepareForSend(
-                byte[] data,
-                int offset,
-                int length)
+                byte[] buffer,
+                int length,
+                int offset = 0)
             {
+                // setup the data payload
                 DataLength = (uint)length;
-                if(Data.Length < DataLength + NameLength)
-                {
-                    byte[] bytes = new byte[Data.Length];
-                    Array.Copy(Data, 0, bytes, 0, Data.Length);
-                    Data = new byte[DataLength + NameLength];
-                    Array.Copy(bytes, 0, Data, 0, bytes.Length);
-                }
 
-                Array.Copy(data, offset, Data, NameLength, length);
+                // need to resize the data buffer to accommodate the buffer data
+                Array.Resize(ref Data, (int)DataLength + (int)NameLength);
+
+                // copy the buffer data to the data buffer
+                Array.Copy(buffer, offset, Data, NameLength, length);
 
                 return true;
             }

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -58,6 +58,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         public const uint c_Monitor_OemInfo = 0x0000000E;
         public const uint c_Monitor_QueryConfiguration = 0x0000000F;
         public const uint c_Monitor_UpdateConfiguration = 0x00000010;
+        public const uint c_Monitor_StorageOperation = 0x00000011;
         public const uint c_Monitor_TargetInfo = 0x00000020;
 
         public class Monitor_Message : IConverter
@@ -526,6 +527,87 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 Array.Copy(data, offset, Data, 0, length);
 
                 return true;
+            }
+        }
+       
+        /// <summary>
+        /// Perform storage operation on the target device.
+        /// </summary>
+        public class Monitor_StorageOperation : OverheadBase
+        {
+            public StorageOperation Operation = StorageOperation.None;
+            public string StorageName = null;
+            public uint Length = 0;
+            public byte[] Data = null;
+
+            public class Reply
+            {
+                public uint ErrorCode;
+            };
+
+            public void PrepareForSend(
+              StorageOperation operation,
+              string name)
+            {
+                Operation = operation;
+                StorageName = name;
+            }
+
+            public void PrepareForSend(
+                StorageOperation operation,
+                string name,
+                byte[] data,
+                int offset,
+                int length)
+            {
+                Operation = operation;
+                StorageName = name;
+
+                PrepareForSend(data, offset, length);
+            }
+
+            public override bool PrepareForSend(
+                byte[] data,
+                int offset,
+                int length)
+            {
+                Length = (uint)length;
+                Data = new byte[length];
+
+                Array.Copy(data, offset, Data, 0, length);
+
+                return true;
+            }
+
+            //////////////////////////////////////////////////////////////////////////////////////
+            // !!! KEEP IN SYNC WITH typedef enum Monitor_StorageOperation (in native code) !!! //
+            //////////////////////////////////////////////////////////////////////////////////////
+
+            /// <summary>
+            /// Storage operation to be performed.
+            /// </summary>
+            public enum StorageOperation : byte
+            {
+                /// <summary>
+                /// Not specified.
+                /// </summary>
+                None = 0,
+
+                /// <summary>
+                /// Write to storage.
+                /// </summary>
+                /// <remarks>
+                /// If the file already exists, it will be overwritten.
+                /// </remarks>
+                Write = 1,
+
+                /// <summary>
+                /// Delete from storage.
+                /// </summary>
+                /// <remarks>
+                /// If the file doesn't exist, no action is taken.
+                /// </remarks>
+                Delete = 2
             }
         }
 

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -64,6 +64,11 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         /// Delete error.
         /// </summary>
         DeleteError = 0x0020,
+
+        /// <summary>
+        /// Platform dependent error.
+        /// </summary>
+        PlatformError = 0x0030,
     }
 
     public class Commands

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -643,6 +643,13 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 return true;
             }
 
+            internal void PrepareForSend()
+            {
+                // add the file name to the data property buffer
+                Data = Encoding.UTF8.GetBytes(FileName);
+                NameLength = (uint)FileName.Length;
+            }
+
             //////////////////////////////////////////////////////////////////////////////////////
             // !!! KEEP IN SYNC WITH typedef enum Monitor_StorageOperation (in native code) !!! //
             //////////////////////////////////////////////////////////////////////////////////////

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -560,9 +560,32 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         /// </summary>
         public class Monitor_StorageOperation : OverheadBase
         {
+            /// <summary>
+            /// Storage operation to be performed.
+            /// </summary>
             public uint Operation = (byte)StorageOperation.None;
+
+            /// <summary>
+            /// Length of the name of the file to be used in the operation.
+            /// </summary>
             public uint NameLength = 0;
+
+            /// <summary>
+            /// Length of the data to be used in the operation.
+            /// </summary>
             public uint DataLength = 0;
+
+            /// <summary>
+            /// Offset in the file data of the chunck in this operation.
+            /// </summary>
+            /// <remarks>
+            /// This is to be used by the target device to know where to start writing the chunk data.
+            /// </remarks>
+            public uint Offset = 0;
+
+            /// <summary>
+            /// Data buffer to be sent to the device.
+            /// </summary>
             public byte[] Data = new byte[0];
 
             public class Reply

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -571,6 +571,12 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             public uint Operation = (byte)StorageOperation.None;
 
             /// <summary>
+            /// File name for the the storage operation.
+            /// </summary>
+            [IgnoreDataMember]
+            public string FileName = string.Empty;
+
+            /// <summary>
             /// Length of the name of the file to be used in the operation.
             /// </summary>
             public uint NameLength = 0;
@@ -591,7 +597,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             /// <summary>
             /// Data buffer to be sent to the device.
             /// </summary>
-            public byte[] Data = new byte[0];
+            public byte[] Data;
 
             public class Reply
             {
@@ -607,9 +613,8 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
               StorageOperation operation,
               string name)
             {
-                Operation = (byte)operation;
-                Data = Encoding.UTF8.GetBytes(name);
-                NameLength = (uint)Data.Length;
+                Operation = (uint)operation;
+                FileName = name;
             }
 
             /// <summary>
@@ -625,11 +630,14 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             {
                 // setup the data payload
                 DataLength = (uint)length;
+                Data = new byte[length + FileName.Length];
 
-                // need to resize the data buffer to accommodate the buffer data
-                Array.Resize(ref Data, (int)DataLength + (int)NameLength);
+                // add the file name to the data property buffer
+                var tempName = Encoding.UTF8.GetBytes(FileName);
+                NameLength = (uint)tempName.Length;
+                Array.Copy(tempName, 0, Data, 0, NameLength);
 
-                // copy the buffer data to the data buffer
+                // copy the buffer data to the data property buffer
                 Array.Copy(buffer, offset, Data, NameLength, length);
 
                 return true;

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -41,24 +41,27 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         Unknown = 0xFFFF,
     }
 
-    public enum StorageOperationErrorCodes : uint
+    /// <summary>
+    /// Storage operation error codes.
+    /// </summary>
+    public enum StorageOperationErrorCode : uint
     {
         ////////////////////////////////////////////////////////////////////////////////////////////
-        // NEED TO KEEP THESE IN SYNC WITH native 'StorageOperationErrorCodes' enum in Debugger.h //
+        // NEED TO KEEP THESE IN SYNC WITH native 'StorageOperationErrorCode' enum in Debugger.h //
         ////////////////////////////////////////////////////////////////////////////////////////////
 
         /// <summary>
-        /// No error
+        /// No error.
         /// </summary>
         NoError = 0x0001,
 
         /// <summary>
-        /// Write error
+        /// Write error.
         /// </summary>
         WriteError = 0x0010,
 
         /// <summary>
-        /// Delete error
+        /// Delete error.
         /// </summary>
         DeleteError = 0x0020,
     }

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -46,9 +46,9 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
     /// </summary>
     public enum StorageOperationErrorCode : uint
     {
-        ////////////////////////////////////////////////////////////////////////////////////////////
+        ///////////////////////////////////////////////////////////////////////////////////////////
         // NEED TO KEEP THESE IN SYNC WITH native 'StorageOperationErrorCode' enum in Debugger.h //
-        ////////////////////////////////////////////////////////////////////////////////////////////
+        ///////////////////////////////////////////////////////////////////////////////////////////
 
         /// <summary>
         /// No error.
@@ -554,7 +554,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 return true;
             }
         }
-       
+
         /// <summary>
         /// Perform storage operation on the target device.
         /// </summary>
@@ -1998,7 +1998,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             while (len < num && buf[len] != 0) len++;
 
             if (fUTF8) return Encoding.UTF8.GetString(buf, 0, len);
-            else return Encoding.UTF8.GetString(buf, 0, len);
+            else return Encoding.ASCII.GetString(buf, 0, len);
         }
 
         public static object ResolveCommandToPayload(uint cmd, bool fReply, CLRCapabilities capabilities)

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -551,6 +551,87 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 return true;
             }
         }
+       
+        /// <summary>
+        /// Perform storage operation on the target device.
+        /// </summary>
+        public class Monitor_StorageOperation : OverheadBase
+        {
+            public StorageOperation Operation = StorageOperation.None;
+            public uint Length = 0;
+            public string StorageName = null;
+            public byte[] Data = null;
+
+            public class Reply
+            {
+                public uint ErrorCode;
+            };
+
+            public void PrepareForSend(
+              StorageOperation operation,
+              string name)
+            {
+                Operation = operation;
+                StorageName = name;
+            }
+
+            public void PrepareForSend(
+                StorageOperation operation,
+                string name,
+                byte[] data,
+                int offset,
+                int length)
+            {
+                Operation = operation;
+                StorageName = name;
+
+                PrepareForSend(data, offset, length);
+            }
+
+            public override bool PrepareForSend(
+                byte[] data,
+                int offset,
+                int length)
+            {
+                Length = (uint)length;
+                Data = new byte[length];
+
+                Array.Copy(data, offset, Data, 0, length);
+
+                return true;
+            }
+
+            //////////////////////////////////////////////////////////////////////////////////////
+            // !!! KEEP IN SYNC WITH typedef enum Monitor_StorageOperation (in native code) !!! //
+            //////////////////////////////////////////////////////////////////////////////////////
+
+            /// <summary>
+            /// Storage operation to be performed.
+            /// </summary>
+            public enum StorageOperation : byte
+            {
+                /// <summary>
+                /// Not specified.
+                /// </summary>
+                None = 0,
+
+                /// <summary>
+                /// Write to storage.
+                /// </summary>
+                /// <remarks>
+                /// If the file already exists, it will be overwritten.
+                /// </remarks>
+                Write = 1,
+
+                /// <summary>
+                /// Delete from storage.
+                /// </summary>
+                /// <remarks>
+                /// If the file doesn't exist, no action is taken.
+                /// </remarks>
+                Delete = 2
+            }
+        }
 
         /// <summary>
         /// Perform storage operation on the target device.

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -69,6 +69,15 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         /// Platform dependent error.
         /// </summary>
         PlatformError = 0x0030,
+
+        /////////////////////////////////////////////////////////
+        // The following element is not present in native code //
+        /////////////////////////////////////////////////////////
+        
+        /// <summary>
+        /// Target does not support storage operations.
+        /// </summary>
+        NotSupported = 0xFFFF,
     }
 
     public class Commands

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -41,6 +41,28 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         Unknown = 0xFFFF,
     }
 
+    public enum StorageOperationErrorCodes : uint
+    {
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        // NEED TO KEEP THESE IN SYNC WITH native 'StorageOperationErrorCodes' enum in Debugger.h //
+        ////////////////////////////////////////////////////////////////////////////////////////////
+
+        /// <summary>
+        /// No error
+        /// </summary>
+        NoError = 0x0001,
+
+        /// <summary>
+        /// Write error
+        /// </summary>
+        WriteError = 0x0010,
+
+        /// <summary>
+        /// Delete error
+        /// </summary>
+        DeleteError = 0x0020,
+    }
+
     public class Commands
     {
         public const uint c_Monitor_Ping = 0x00000000; // The payload is empty, this command is used to let the other side know we are here...
@@ -529,14 +551,14 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 return true;
             }
         }
-       
+
         /// <summary>
         /// Perform storage operation on the target device.
         /// </summary>
         public class Monitor_StorageOperation : OverheadBase
         {
             public StorageOperation Operation = StorageOperation.None;
-            public string StorageName = null;
+            public string StorageName = string.Empty;
             public uint Length = 0;
             public byte[] Data = null;
 
@@ -1960,6 +1982,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                     case c_Monitor_FlashSectorMap: return new Monitor_FlashSectorMap.Reply();
                     case c_Monitor_QueryConfiguration: return new Monitor_QueryConfiguration.Reply();
                     case c_Monitor_UpdateConfiguration: return new Monitor_UpdateConfiguration.Reply();
+                    case c_Monitor_StorageOperation: return new Monitor_StorageOperation.Reply();
 
                     case c_Debugging_Execution_BasePtr: return new Debugging_Execution_BasePtr.Reply();
                     case c_Debugging_Execution_ChangeConditions: return new DebuggingExecutionChangeConditions.Reply();
@@ -2033,6 +2056,7 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                     case c_Monitor_DeploymentMap: return new Monitor_DeploymentMap();
                     case c_Monitor_FlashSectorMap: return new Monitor_FlashSectorMap();
                     case c_Monitor_QueryConfiguration: return new Monitor_QueryConfiguration();
+                    case c_Monitor_StorageOperation: return new Monitor_StorageOperation();
 
                     case c_Debugging_Execution_BasePtr: return new Debugging_Execution_BasePtr();
                     case c_Debugging_Execution_ChangeConditions: return new DebuggingExecutionChangeConditions();

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -4423,6 +4423,35 @@ namespace nanoFramework.Tools.Debugger
             return (int)WireProtocolPacketSize - cmd.Overhead;
         }
 
+        public StorageOperationErrorCodes AddFile(string fileName, byte[] fileContent)
+        {
+            var storop = new Commands.Monitor_StorageOperation();
+            storop.PrepareForSend(Commands.Monitor_StorageOperation.StorageOperation.Write, fileName, fileContent, 0, fileContent.Length);
+            IncomingMessage reply = PerformSyncRequest(Commands.c_Monitor_StorageOperation, 0, storop);
+            if (reply != null)
+            {
+                Commands.Monitor_StorageOperation.Reply cmdReply = reply.Payload as Commands.Monitor_StorageOperation.Reply;
+                return (StorageOperationErrorCodes)cmdReply.ErrorCode;
+            }
+
+            return StorageOperationErrorCodes.WriteError;
+        }
+
+        public StorageOperationErrorCodes RemoveFile(string fileName)
+        {
+            var storop = new Commands.Monitor_StorageOperation();
+            storop.PrepareForSend(Commands.Monitor_StorageOperation.StorageOperation.Delete, fileName);
+            IncomingMessage reply = PerformSyncRequest(Commands.c_Monitor_StorageOperation, 0, storop);
+            if (reply != null)
+            {
+                Commands.Monitor_StorageOperation.Reply cmdReply = reply.Payload as Commands.Monitor_StorageOperation.Reply;
+                return (StorageOperationErrorCodes)cmdReply.ErrorCode;
+            }
+
+            return StorageOperationErrorCodes.WriteError;
+        }
+
+
         /// <summary>
         /// Writes a specific configuration block to the device.
         /// The configuration block is updated only with the changes for this configuration part.

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -4494,6 +4494,8 @@ namespace nanoFramework.Tools.Debugger
                 Commands.Monitor_StorageOperation.StorageOperation.Delete,
                 fileName);
 
+            storop.PrepareForSend();
+
             IncomingMessage reply = PerformSyncRequest(
                 Commands.c_Monitor_StorageOperation,
                 0,


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
- Add Storage Operation Command
- AddFile and RemoveFile support
- Split the byte array to save as a file in chunks internally and pass it to the device
- Added 2 buttons to add and remove a file in the WPF test application

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Allow to perform operations in target storage to allow storing and deleting files from VS and/or nanoff.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a real ESP32 device

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
