### PR TITLE
Extra overloads for GlobalExclusiveDeviceAccess.CommunicateWithDevice.

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/GlobalExclusiveDeviceAccess.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/GlobalExclusiveDeviceAccess.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using nanoFramework.Tools.Debugger.PortTcpIp;
 
 namespace nanoFramework.Tools.Debugger.NFDevice
@@ -24,6 +25,78 @@ namespace nanoFramework.Tools.Debugger.NFDevice
 
         #region Methods
         /// <summary>
+        /// Communicate with a connected device and ensure the code to be executed as exclusive access to the device.
+        /// </summary>
+        /// <param name="device">The connected device.</param>
+        /// <param name="communication">Code to execute while having exclusive access to the device</param>
+        /// <param name="millisecondsTimeout">Maximum time in milliseconds to wait for exclusive access</param>
+        /// <param name="cancellationToken">Cancellation token that can be cancelled to stop/abort running the <paramref name="communication"/>.
+        /// This method does not stop/abort execution of <paramref name="communication"/> after it has been started.</param>
+        /// <returns>Indicates whether the <paramref name="communication"/> has been executed. Returns <c>false</c> if exclusive access
+        /// cannot be obtained within <paramref name="millisecondsTimeout"/>, or if <paramref name="cancellationToken"/> was cancelled
+        /// before the <paramref name="communication"/> has been started.</returns>
+        public static bool CommunicateWithDevice(NanoDeviceBase device, Action communication, int millisecondsTimeout = Timeout.Infinite, CancellationToken? cancellationToken = null)
+        {
+            return DoCommunicateWithDevice(device.ConnectionPort.InstanceId, communication, millisecondsTimeout, cancellationToken);
+        }
+
+        /// <summary>
+        /// Communicate with a connected device and ensure the code to be executed as exclusive access to the device.
+        /// </summary>
+        /// <param name="device">The connected device.</param>
+        /// <param name="communicationAsync">Code to execute while having exclusive access to the device</param>
+        /// <param name="millisecondsTimeout">Maximum time in milliseconds to wait for exclusive access</param>
+        /// <param name="cancellationToken">Cancellation token that can be cancelled to stop/abort running the <paramref name="communicationAsync"/>.
+        /// This method does not stop/abort execution of <paramref name="communicationAsync"/> after it has been started.</param>
+        /// <returns>Indicates whether the <paramref name="communicationAsync"/> has been executed. Returns <c>false</c> if exclusive access
+        /// cannot be obtained within <paramref name="millisecondsTimeout"/>, or if <paramref name="cancellationToken"/> was cancelled
+        /// before the <paramref name="communicationAsync"/> has been started.</returns>
+        public static bool CommunicateWithDevice(NanoDeviceBase device, Func<Task> communicationAsync, int millisecondsTimeout = Timeout.Infinite, CancellationToken? cancellationToken = null)
+        {
+            return DoCommunicateWithDevice(
+                device.ConnectionPort.InstanceId,
+                () => communicationAsync()?.GetAwaiter().GetResult(),
+                millisecondsTimeout,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Communicate with a connected device and ensure the code to be executed as exclusive access to the device.
+        /// </summary>
+        /// <param name="port">The port the device is connected to.</param>
+        /// <param name="communication">Code to execute while having exclusive access to the device</param>
+        /// <param name="millisecondsTimeout">Maximum time in milliseconds to wait for exclusive access</param>
+        /// <param name="cancellationToken">Cancellation token that can be cancelled to stop/abort running the <paramref name="communication"/>.
+        /// This method does not stop/abort execution of <paramref name="communication"/> after it has been started.</param>
+        /// <returns>Indicates whether the <paramref name="communication"/> has been executed. Returns <c>false</c> if exclusive access
+        /// cannot be obtained within <paramref name="millisecondsTimeout"/>, or if <paramref name="cancellationToken"/> was cancelled
+        /// before the <paramref name="communication"/> has been started.</returns>
+        public static bool CommunicateWithDevice(IPort port, Action communication, int millisecondsTimeout = Timeout.Infinite, CancellationToken? cancellationToken = null)
+        {
+            return DoCommunicateWithDevice(port.InstanceId, communication, millisecondsTimeout, cancellationToken);
+        }
+
+        /// <summary>
+        /// Communicate with a connected device and ensure the code to be executed as exclusive access to the device.
+        /// </summary>
+        /// <param name="port">The port the device is connected to.</param>
+        /// <param name="communicationAsync">Code to execute while having exclusive access to the device</param>
+        /// <param name="millisecondsTimeout">Maximum time in milliseconds to wait for exclusive access</param>
+        /// <param name="cancellationToken">Cancellation token that can be cancelled to stop/abort running the <paramref name="communicationAsync"/>.
+        /// This method does not stop/abort execution of <paramref name="communicationAsync"/> after it has been started.</param>
+        /// <returns>Indicates whether the <paramref name="communicationAsync"/> has been executed. Returns <c>false</c> if exclusive access
+        /// cannot be obtained within <paramref name="millisecondsTimeout"/>, or if <paramref name="cancellationToken"/> was cancelled
+        /// before the <paramref name="communicationAsync"/> has been started.</returns>
+        public static bool CommunicateWithDevice(IPort port, Func<Task> communicationAsync, int millisecondsTimeout = Timeout.Infinite, CancellationToken? cancellationToken = null)
+        {
+            return DoCommunicateWithDevice(
+                port.InstanceId,
+                () => communicationAsync()?.GetAwaiter().GetResult(),
+                millisecondsTimeout,
+                cancellationToken);
+        }
+
+        /// <summary>
         /// Communicate with a serial device and ensure the code to be executed as exclusive access to the device.
         /// </summary>
         /// <param name="serialPort">The serial port the device is connected to.</param>
@@ -37,6 +110,26 @@ namespace nanoFramework.Tools.Debugger.NFDevice
         public static bool CommunicateWithDevice(string serialPort, Action communication, int millisecondsTimeout = Timeout.Infinite, CancellationToken? cancellationToken = null)
         {
             return DoCommunicateWithDevice(serialPort, communication, millisecondsTimeout, cancellationToken);
+        }
+
+        /// <summary>
+        /// Communicate with a serial device and ensure the code to be executed as exclusive access to the device.
+        /// </summary>
+        /// <param name="serialPort">The serial port the device is connected to.</param>
+        /// <param name="communicationAsync">Code to execute while having exclusive access to the device</param>
+        /// <param name="millisecondsTimeout">Maximum time in milliseconds to wait for exclusive access</param>
+        /// <param name="cancellationToken">Cancellation token that can be cancelled to stop/abort running the <paramref name="communicationAsync"/>.
+        /// This method does not stop/abort execution of <paramref name="communicationAsync"/> after it has been started.</param>
+        /// <returns>Indicates whether the <paramref name="communicationAsync"/> has been executed. Returns <c>false</c> if exclusive access
+        /// cannot be obtained within <paramref name="millisecondsTimeout"/>, or if <paramref name="cancellationToken"/> was cancelled
+        /// before the <paramref name="communicationAsync"/> has been started.</returns>
+        public static bool CommunicateWithDevice(string serialPort, Func<Task> communicationAsync, int millisecondsTimeout = Timeout.Infinite, CancellationToken? cancellationToken = null)
+        {
+            return DoCommunicateWithDevice(
+                serialPort,
+                () => communicationAsync()?.GetAwaiter().GetResult(),
+                millisecondsTimeout,
+                cancellationToken);
         }
 
         /// <summary>
@@ -54,17 +147,37 @@ namespace nanoFramework.Tools.Debugger.NFDevice
         {
             return DoCommunicateWithDevice($"{address.Host}:{address.Port}", communication, millisecondsTimeout, cancellationToken);
         }
+
+        /// <summary>
+        /// Communicate with a device accessible via the network and ensure the code to be executed as exclusive access to the device.
+        /// </summary>
+        /// <param name="address">The network address the device is connected to.</param>
+        /// <param name="communicationAsync">Code to execute while having exclusive access to the device</param>
+        /// <param name="millisecondsTimeout">Maximum time in milliseconds to wait for exclusive access</param>
+        /// <param name="cancellationToken">Cancellation token that can be cancelled to stop/abort running the <paramref name="communicationAsync"/>.
+        /// This method does not stop/abort execution of <paramref name="communicationAsync"/> after it has been started.</param>
+        /// <returns>Indicates whether the <paramref name="communicationAsync"/> has been executed. Returns <c>false</c> if exclusive access
+        /// cannot be obtained within <paramref name="millisecondsTimeout"/>, or if <paramref name="cancellationToken"/> was cancelled
+        /// before the <paramref name="communicationAsync"/> has been started.</returns>
+        public static bool CommunicateWithDevice(NetworkDeviceInformation address, Func<Task> communicationAsync, int millisecondsTimeout = Timeout.Infinite, CancellationToken? cancellationToken = null)
+        {
+            return DoCommunicateWithDevice(
+                $"{address.Host}:{address.Port}",
+                () => communicationAsync()?.GetAwaiter().GetResult(),
+                millisecondsTimeout,
+                cancellationToken);
+        }
         #endregion
 
         #region Implementation
-        private static bool DoCommunicateWithDevice(string connectionKey, Action communication, int millisecondsTimeout, CancellationToken? cancellationToken)
+        private static bool DoCommunicateWithDevice(string portInstanceId, Action communication, int millisecondsTimeout, CancellationToken? cancellationToken)
         {
             for (bool retry = true; retry;)
             {
                 retry = false;
 
                 var waitHandles = new List<WaitHandle>();
-                var mutex = new Mutex(false, $"{MutexBaseName}{connectionKey}");
+                var mutex = new Mutex(false, $"{MutexBaseName}{portInstanceId}");
                 waitHandles.Add(mutex);
 
                 CancellationTokenSource timeOutToken = null;
@@ -83,7 +196,7 @@ namespace nanoFramework.Tools.Debugger.NFDevice
                 {
                     if (WaitHandle.WaitAny(waitHandles.ToArray()) == 0)
                     {
-                        communication();
+                        communication?.Invoke();
                         return true;
                     }
                 }


### PR DESCRIPTION
## Description

Added overloads for GlobalExclusiveDeviceAccess.CommunicateWithDevice:

- accepting NanoDeviceBase or IPort as argument, in addition to serialPort and NetworkDeviceInformation
- accepting `Func<Task> communicationAsync` as argument, in addition to `Action communication`:

Now you can write:
```
GlobalExclusiveDeviceAccess.CommunicateWithDevice(
	device, 
	async () => 
	{ 
		await PingAsync (); 
	}
);
```

## Motivation and Context

In nanoff the action to be protected is async code, but the GlobalExclusiveDeviceAccess did not have a method for that.

While trying to add the lock to the Device Explorer (e.g., for the Ping command): the code only knows about NanoDeviceBase, how to get from that to a serial port or network address should not be part of the Device Explorer code.

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
