### PR TITLE
Fix to restore Unix-compatibility

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/GlobalExclusiveDeviceAccess.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/GlobalExclusiveDeviceAccess.cs
@@ -181,7 +181,11 @@ namespace nanoFramework.Tools.Debugger.NFDevice
                     var mutex = new Semaphore(
                         0,
                         1,
-                        $"{MutexBaseName}{portInstanceId}",
+                        Environment.OSVersion.Platform == PlatformID.Win32NT
+                            // A named Semaphore is only supported on Windows OS, and is global - for all processes.
+                            ? $"{MutexBaseName}{portInstanceId}"
+                            // On other platforms the access is not inter-process but restricted to the current process.
+                            : null,
                         out bool createdNew);
 
                     if (createdNew)


### PR DESCRIPTION
## Description

Fix to prevent exceptions on Unix. This is the quick fix. The result is that GlobalExclusiveDeviceAccess is only global (inter-process) on the Windows OS (both .NET-for-windows and .NET in WSL). On other platforms it is only exclusive within  a process (same as `lock () { }`).

When working on the original PR, I've looked for a cross-platform alternative for Semaphore but I couldn't find one out o the box. Suggestions on the internet are to use named pipes or create something based on temporary files. The latter is probably the easiest, I've done something like that before. It may not be a lot of work, but... I can't test the code on anything else than Windows.

## Motivation and Context

The use of a named Semaphore in GlobalExclusiveDeviceAccess results in exceptions on Unix.

## How Has This Been Tested?

I can't test this on anything else than Windows.

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
