### PR TITLE
Allow PortBase and NanoDeviceBase to be used in mocks

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
@@ -1,8 +1,5 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;
@@ -69,7 +66,7 @@ namespace nanoFramework.Tools.Debugger
         /// <summary>
         /// Detailed info about the NanoFramework device hardware, solution and CLR.
         /// </summary>
-        public INanoFrameworkDeviceInfo DeviceInfo { get; internal set; }
+        public INanoFrameworkDeviceInfo DeviceInfo { get; protected internal set; }
 
         /// <summary>
         /// Version of nanoBooter.

--- a/nanoFramework.Tools.DebugLibrary.Shared/PortDefinitions/PortBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortDefinitions/PortBase.cs
@@ -48,9 +48,9 @@ namespace nanoFramework.Tools.Debugger
         /// <summary>
         /// Flag to signal that devices enumeration is complete.
         /// </summary>
-        public bool IsDevicesEnumerationComplete { get; internal set; } = false;
+        public virtual bool IsDevicesEnumerationComplete { get; internal set; } = false;
 
-        public NanoFrameworkDevices NanoFrameworkDevices { get; }
+        public virtual NanoFrameworkDevices NanoFrameworkDevices { get; }
 
         /// <summary>
         /// Adds a new device to list of NanoFrameworkDevices.


### PR DESCRIPTION
## Description
- NanoDeviceBase.DeviceInfo property can be assigned from a derived class
- PortBase.IsDevicesEnumerationComplete made virtual
- PortBase.NanoFrameworkDevices made virtual

## Motivation and Context

I'm refactoring my new test framework code, in preparation for the creation of PRs. To test some of the code, it is necessary to have control in unit tests over the available nanoDevices. The discovery of devices and information about devices is done via class derived from PortBase and NanoDeviceBase. The unit tests would need to implement mocks for these abstract classes. In the current version of the library it is not possible to set the three properties mentioned above. In my current version of the test framework, I'm using mockable wrappers for NanoDevice en NanoFrameworkDevices to work around that. But with three changes to the library I can remove those wrappers and use PortBase and NanoDeviceBase directly for mocks:

*  NanoDeviceBase.DeviceInfo - internal set method is a problem is as the DeviceInfo property is the only way to get the unique system serial number of the connected device
*  PortBase.NanoFrameworkDevices - it is always set to the global instance of a list of devices, but in a unit test you want to work with a single list per unit test.
* PortBase.IsDevicesEnumerationComplete - internal set method is a problem. Instead of making the set method `protected internal`, making it virtual allows for a wider use. It is then possible to have mocks that are a wrapper around another PortBase implementation without having to duplicate the IsDevicesEnumerationComplete logic.

The changes have no effect on the existing code. 

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
