### PR TITLE
NanoDeviceBase.CLRVersion made virtual

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
@@ -89,7 +89,7 @@ namespace nanoFramework.Tools.Debugger
         /// <summary>
         /// Version of nanoCLR.
         /// </summary>
-        public Version CLRVersion
+        public virtual Version CLRVersion
         {
             get
             {


### PR DESCRIPTION
## Description

* NanoDeviceBase.CLRVersion made virtual

## Motivation and Context

Missed this one in the previous PR, didn't notice it cannot be assigned like the other properties. Same story: in a mock of NanoDeviceBase you would want to specify the firmware version, to check whether it is the version required for the project.

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
