### PR TITLE
Fixing configuration block deployment and Wireless AP Network type

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/NetworkInformation/NetworkInterfaceType.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NetworkInformation/NetworkInterfaceType.cs
@@ -33,5 +33,12 @@ namespace nanoFramework.Tools.Debugger
         /// </summary>
         [Description("Wi-Fi (802.11)")]
         Wireless80211 = 71,
+
+
+        /// <summary>
+        /// The network interface uses a wireless Soft AP connection (IEEE 802.11 standard).
+        /// </summary>
+        [Description("Wi-Fi Access Point (802.11)")]
+        WirelessAP = 72,
     }
 }

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -4147,7 +4147,7 @@ namespace nanoFramework.Tools.Debugger
                             networkConfiguration.StartupAddressMode = (byte)AddressMode.Invalid;
                         }
 
-                        if (networkConfiguration.InterfaceType > (byte)NetworkInterfaceType.Wireless80211)
+                        if (networkConfiguration.InterfaceType > (byte)NetworkInterfaceType.WirelessAP)
                         {
                             // fix this to invalid
                             networkConfiguration.InterfaceType = (byte)NetworkInterfaceType.Unknown;
@@ -4776,7 +4776,8 @@ namespace nanoFramework.Tools.Debugger
                 {
                     Commands.Monitor_UpdateConfiguration cmd = new Commands.Monitor_UpdateConfiguration
                     {
-                        Configuration = (uint)GetDeviceConfigurationOption(configuration)
+                        Configuration = (uint)GetDeviceConfigurationOption(configuration),
+                        BlockIndex = blockIndex,
                     };
 
                     // get packet length, either the maximum allowed size or whatever is still available to TX


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
Fixing configuration block deployment and Wireless AP Network type

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Fixing configuration block deployment and Wireless AP Network type
- Resolves nanoframework/Home#1593.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a real ESP32S3 device with the nf-interperter fix nanoframework/nf-interpreter/pull/3077.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
