### PR TITLE
Fix rescan serial devices

### DIFF
--- a/USB Test App WPF/MainWindow.xaml.cs
+++ b/USB Test App WPF/MainWindow.xaml.cs
@@ -919,28 +919,29 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
             (sender as Button).IsEnabled = true;
         }
 
-        private void ReScanDevices_Click(object sender, RoutedEventArgs e)
+        private async void ReScanDevices_Click(object sender, RoutedEventArgs e)
         {
-            // disable button
-            (sender as Button).IsEnabled = false;
+            var button = (Button)sender;
+            button.IsEnabled = false;
 
-            Task.Run(delegate
+            // Capture the client reference on the UI thread before handing off to the background thread.
+            // DataContext is a DependencyObject property that must only be accessed from the UI thread.
+            PortBase debugClient = (DataContext as MainViewModel).SerialDebugService.SerialDebugClient;
+
+            try
             {
-                Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() =>
+                debugClient.ReScanDevices();
+
+                // Wait for enumeration to complete without blocking the UI thread.
+                while (!debugClient.IsDevicesEnumerationComplete)
                 {
-                    (DataContext as MainViewModel).SerialDebugService.SerialDebugClient.ReScanDevices();
-
-                    // need to wait for devices enumeration to complete
-                    while (!(DataContext as MainViewModel).SerialDebugService.SerialDebugClient.IsDevicesEnumerationComplete)
-                    {
-                        Thread.Sleep(100);
-                    }
-
-                    // enable button
-                    (sender as Button).IsEnabled = true;
-                }));
-
-            });
+                    await Task.Delay(100);
+                }
+            }
+            finally
+            {
+                button.IsEnabled = true;
+            }
         }
 
         private void ReadTestButton_Click(object sender, RoutedEventArgs e)

--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/DeviceWatcher.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/DeviceWatcher.cs
@@ -83,16 +83,28 @@ namespace nanoFramework.Tools.Debugger.PortSerial
         {
             if (!_started)
             {
-                _threadWatch = new Thread(() =>
+                try
                 {
-                    StartWatcher(portsToExclude ?? []);
-                })
-                {
-                    IsBackground = true,
-                    Priority = ThreadPriority.Lowest
-                };
+                    _threadWatch = new Thread(() =>
+                    {
+                        StartWatcher(portsToExclude ?? []);
+                    })
+                    {
+                        IsBackground = true,
+                        Priority = ThreadPriority.Lowest
+                    };
 
-                _threadWatch.Start();
+                    _threadWatch.Start();
+
+                    // Set only after the thread has been successfully started
+                    // so Start() can be retried if thread creation or start throws.
+                    _started = true;
+                }
+                catch
+                {
+                    _threadWatch = null;
+                    throw;
+                }
             }
         }
 
@@ -101,8 +113,6 @@ namespace nanoFramework.Tools.Debugger.PortSerial
             _ownerManager.OnLogMessageAvailable($"PortSerial device watcher started @ Thread {_threadWatch.ManagedThreadId} [ProcessID: {Process.GetCurrentProcess().Id}]");
 
             _ports = [];
-
-            _started = true;
 
             #region Support for the AllNewDevicesAdded event
             object allNewDevicesLock = new object();
@@ -186,15 +196,24 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                                 if (PortSerialManager.GetRegisteredDevice(port) is null)
                                 {
                                     bool isOneOfAllNewDevices = true;
+                                    bool shouldRaiseAllNewDevicesAdded = false;
                                     lock (allNewDevicesLock)
                                     {
-                                        if (raiseAllNewDevicesAdded)
+                                        if (raiseAllNewDevicesAdded && allNewDevicesCandidateCount == 0)
                                         {
-                                            allNewDevicesCandidateCount++;
+                                            raiseAllNewDevicesAdded = false;
+                                            shouldRaiseAllNewDevicesAdded = true;
                                         }
-                                        else
+                                    }
+                                    if (shouldRaiseAllNewDevicesAdded)
+                                    {
+                                        try
                                         {
-                                            isOneOfAllNewDevices = false;
+                                            AllNewDevicesAdded?.Invoke(this);
+                                        }
+                                        catch
+                                        {
+                                            // The device watcher must continue
                                         }
                                     }
 
@@ -247,6 +266,27 @@ namespace nanoFramework.Tools.Debugger.PortSerial
                             }
                         }
                     }
+
+                    // If no new device candidates were queued during this first scan pass (either because
+                    // there are no ports at all, or all visible ports are already registered), the
+                    // UpdateAllNewDevices callback will never be called and AllNewDevicesAdded would
+                    // never fire. Fire it explicitly here to unblock enumeration completion.
+                    lock (allNewDevicesLock)
+                    {
+                        if (raiseAllNewDevicesAdded && allNewDevicesCandidateCount == 0)
+                        {
+                            raiseAllNewDevicesAdded = false;
+                            try
+                            {
+                                AllNewDevicesAdded?.Invoke(this);
+                            }
+                            catch
+                            {
+                                // The device watcher must continue
+                            }
+                        }
+                    }
+
                     Thread.Sleep(200);
                 }
 #if DEBUG

--- a/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/PortSerialManager.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/PortSerial/PortSerialManager.cs
@@ -109,13 +109,13 @@ namespace nanoFramework.Tools.Debugger.PortSerial
         /// </summary>
         private void StartDeviceWatchersInternal()
         {
-            // Start all device watchers
+            // Reset flag before starting the watcher so it is already false
+            // when the new watcher thread begins.
+            IsDevicesEnumerationComplete = false;
 
             _deviceWatcher.Start(PortExclusionList);
 
             _watchersStarted = true;
-
-            IsDevicesEnumerationComplete = false;
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
- Fire AllNewDevicesAdded immediately when no port candidates were queued on the first scan pass (zero ports or all already registered), so enumeration completion is never blocked. Also moved _started = true to before _threadWatch.Start() to close a re-entrancy race.
- Reset IsDevicesEnumerationComplete = false before calling Start(), not after, to prevent the new watcher thread from racing ahead and setting it to true before the reset could run.
- Fix test app with capturing the client reference on the UI thread before entering Task.Run; poll IsDevicesEnumerationComplete on the background thread only against that captured reference.

## Motivation and Context
- Fixes potential race condition with serial device watcher.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Serial test app.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
