### PR TITLE
Improvements in StorageOperation command

### DIFF
--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
@@ -586,11 +587,6 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             public string FileName = string.Empty;
 
             /// <summary>
-            /// Length of the name of the file to be used in the operation.
-            /// </summary>
-            public uint NameLength = 0;
-
-            /// <summary>
             /// Length of the data to be used in the operation.
             /// </summary>
             public uint DataLength = 0;
@@ -629,34 +625,44 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             /// <summary>
             /// Prepare for sending a storage operation to the target device.
             /// </summary>
-            /// <param name="buffer">Data buffer to be sent to the device.</param>
-            /// <param name="offset">Offset in the <paramref name="buffer"/> to start copying data from.</param>
-            /// <param name="length">Length of the data to be copied from the <paramref name="buffer"/>.</param>
+            /// <param name="data">Data buffer to be sent to the device.</param>
+            /// <param name="offset">Offset in the <paramref name="data"/> to start copying data from.</param>
+            /// <param name="length">Length of the data to be copied from the <paramref name="data"/>.</param>
             public override bool PrepareForSend(
-                byte[] buffer,
+                byte[] data,
                 int length,
                 int offset = 0)
             {
-                // setup the data payload
-                DataLength = (uint)length;
-                Data = new byte[length + FileName.Length];
+                // add file name to data buffer
+                PrepareForSend();
 
-                // add the file name to the data property buffer
-                var tempName = Encoding.UTF8.GetBytes(FileName);
-                NameLength = (uint)tempName.Length;
-                Array.Copy(tempName, 0, Data, 0, NameLength);
+                // store file data start position
+                int fileDataStart = Data.Length;
 
-                // copy the buffer data to the data property buffer
-                Array.Copy(buffer, offset, Data, NameLength, length);
+                // resize to add file data
+                Array.Resize(ref Data, Data.Length + length);
+
+                // copy the buffer data to the data buffer
+                Array.Copy(
+                    data,
+                    offset,
+                    Data,
+                    fileDataStart,
+                    length);
 
                 return true;
             }
 
             internal void PrepareForSend()
             {
-                // add the file name to the data property buffer
+                // add the file name to the data buffer
                 Data = Encoding.UTF8.GetBytes(FileName);
-                NameLength = (uint)FileName.Length;
+
+                // add room for \0 terminator
+                Array.Resize(ref Data, FileName.Length + 1);
+
+                // add terminator
+                Data[FileName.Length] = 0;
             }
 
             //////////////////////////////////////////////////////////////////////////////////////

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -633,6 +633,8 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 int length,
                 int offset = 0)
             {
+                DataLength = (uint)length;
+
                 // add file name to data buffer
                 PrepareForSend();
 
@@ -657,12 +659,13 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             {
                 // add the file name to the data buffer
                 Data = Encoding.UTF8.GetBytes(FileName);
+                int fileNameByteCount = Data.Length;
 
                 // add room for \0 terminator
-                Array.Resize(ref Data, FileName.Length + 1);
+                Array.Resize(ref Data, fileNameByteCount + 1);
 
                 // add terminator
-                Data[FileName.Length] = 0;
+                Data[fileNameByteCount] = 0;
             }
 
             //////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description
- Dropping name lenght property.
- Replacing with null terminated string.
- Adjust PrepareForSend methods accordingly.
- Adjust parameter name to match declaration.

### ⚠️ **this requires the connected device to run a fw version `>1.17.0.257` with support for this new payload format**

## Motivation and Context
- Simplification of data payload which allows much efficient code in the device.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
