### PR TITLE
Have debugger aware of Mcuboot

### DIFF
--- a/USB Test App WPF/MainWindow.xaml.cs
+++ b/USB Test App WPF/MainWindow.xaml.cs
@@ -132,8 +132,8 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 
                 Debug.WriteLine("Device capabilities:");
 
-                Debug.Write("IFU capable: ");
-                if (device.IsIFUCapable)
+                Debug.Write("Has MCUboot: ");
+                if (device.HasMCUboot)
                 {
                     Debug.WriteLine("YES");
                 }

--- a/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/NanoFrameworkDeviceInfo.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/MFDeployTool/NanoFrameworkDeviceInfo.cs
@@ -249,7 +249,7 @@ namespace nanoFramework.Tools.Debugger
                     {
                         output.AppendLine($"  nanoBooter: v{Dbg.TargetInfo.BooterVersion}");
                     }
-                    output.AppendLine("  IFU capable: " + (Dbg.IsIFUCapable ? "YES" : "NO"));
+                    output.AppendLine("  Has MCUboot: " + (Dbg.HasMCUboot ? "YES" : "NO"));
                     output.AppendLine("  Has proprietary bootloader: " + (Dbg.HasProprietaryBooter ? "YES" : "NO"));
 
                     output.AppendLine();

--- a/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/NFDevice/NanoDeviceBase.cs
@@ -115,9 +115,9 @@ namespace nanoFramework.Tools.Debugger
         public bool HasNanoBooter => DebugEngine != null && DebugEngine.HasNanoBooter;
 
         /// <summary>
-        /// This indicates if the target device is IFU capable.
+        /// This indicates if the target device uses MCUboot as its bootloader.
         /// </summary>
-        public bool IsIFUCapable => DebugEngine != null && DebugEngine.IsIFUCapable;
+        public bool HasMCUboot => DebugEngine != null && DebugEngine.HasMCUboot;
 
         private readonly object m_serverCert = null;
         private readonly Dictionary<uint, string> m_execSrecHash = new Dictionary<uint, string>();

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -204,9 +204,9 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             public const uint Monitor_Ping_c_HasProprietaryBooter = 0x00010000;
 
             /// <summary>
-            /// This flag indicates that the target device is IFU capable.
+            /// This flag indicates that the device uses MCUboot as its bootloader.
             /// </summary>
-            public const uint Monitor_Ping_c_IFUCapable = 0x00020000;
+            public const uint Monitor_Ping_c_HasMCUboot = 0x00020000;
 
             /// <summary>
             /// This flag indicates that the device requires that the configuration block to be erased before updating it.
@@ -217,6 +217,13 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
             /// This flag indicates that the device has nanoBooter.
             /// </summary>
             public const uint Monitor_Ping_c_HasNanoBooter = 0x00080000;
+
+            // MCUboot image header size (4th position), only meaningful together with Monitor_Ping_c_HasMCUboot.
+            public const uint Monitor_Ping_c_HeaderSize_Position = 0x00700000;
+            public const uint Monitor_Ping_c_HeaderSize_0x200 = 0x00100000;
+            public const uint Monitor_Ping_c_HeaderSize_0x400 = 0x00200000;
+            public const uint Monitor_Ping_c_HeaderSize_0x800 = 0x00300000;
+            public const uint Monitor_Ping_c_HeaderSize_0x1000 = 0x00400000;
 
             ///////////////////////////////////////////////////////////////////////
 

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -314,7 +314,7 @@ namespace nanoFramework.Tools.Debugger
 
                                 default:
                                     // unrecognized/unreported header size: can't safely compose MCUboot images
-                                    throw new NotSupportedException("MCUboot image header size reported by target device is not supported.");
+                                    goto connect_failed;
                             }
                         }
 
@@ -3223,7 +3223,7 @@ namespace nanoFramework.Tools.Debugger
             // check if we do have the map
             if (FlashSectorMap.Count != 0)
             {
-                List<byte[]> chunksToWrite = assemblies;
+                List<byte[]> chunksToWrite = new List<byte[]>(assemblies);
 
                 if (HasMCUboot)
                 {

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -153,9 +154,15 @@ namespace nanoFramework.Tools.Debugger
         public bool HasNanoBooter { get; private set; }
 
         /// <summary>
-        ///  This indicates if the target device is IFU capable.
+        /// This indicates if the target device uses MCUboot as its bootloader.
         /// </summary>
-        public bool IsIFUCapable { get; private set; }
+        public bool HasMCUboot { get; private set; }
+
+        /// <summary>
+        /// The size, in bytes, of the MCUboot image header reserved at the start of each image
+        /// slot on this device. Only meaningful when <see cref="HasMCUboot"/> is <see langword="true"/>.
+        /// </summary>
+        public uint McubootHeaderSize { get; private set; }
 
         public bool IsConnected { get; internal set; }
 
@@ -286,7 +293,30 @@ namespace nanoFramework.Tools.Debugger
 
                         HasNanoBooter = (reply.Flags & Commands.Monitor_Ping.Monitor_Ping_c_HasNanoBooter).Equals(Commands.Monitor_Ping.Monitor_Ping_c_HasNanoBooter);
 
-                        IsIFUCapable = (reply.Flags & Commands.Monitor_Ping.Monitor_Ping_c_IFUCapable).Equals(Commands.Monitor_Ping.Monitor_Ping_c_IFUCapable);
+                        HasMCUboot = (reply.Flags & Commands.Monitor_Ping.Monitor_Ping_c_HasMCUboot).Equals(Commands.Monitor_Ping.Monitor_Ping_c_HasMCUboot);
+
+                        if (HasMCUboot)
+                        {
+                            switch (reply.Flags & Commands.Monitor_Ping.Monitor_Ping_c_HeaderSize_Position)
+                            {
+                                case Commands.Monitor_Ping.Monitor_Ping_c_HeaderSize_0x200:
+                                    McubootHeaderSize = 0x200;
+                                    break;
+                                case Commands.Monitor_Ping.Monitor_Ping_c_HeaderSize_0x400:
+                                    McubootHeaderSize = 0x400;
+                                    break;
+                                case Commands.Monitor_Ping.Monitor_Ping_c_HeaderSize_0x800:
+                                    McubootHeaderSize = 0x800;
+                                    break;
+                                case Commands.Monitor_Ping.Monitor_Ping_c_HeaderSize_0x1000:
+                                    McubootHeaderSize = 0x1000;
+                                    break;
+
+                                default:
+                                    // unrecognized/unreported header size: can't safely compose MCUboot images
+                                    throw new NotSupportedException("MCUboot image header size reported by target device is not supported.");
+                            }
+                        }
 
 
                         // update flag
@@ -3094,6 +3124,96 @@ namespace nanoFramework.Tools.Debugger
             return reply != null && reply.IsPositiveAcknowledge();
         }
 
+        // MCUboot image_header / TLV constants used to compose a deployment image below.
+        // See struct image_header / image_tlv_info / image_tlv in
+        // boot/bootutil/include/bootutil/image.h (mcu-tools/mcuboot). All fields are little endian,
+        // regardless of target byte order - this is the on-the-wire MCUboot image format, not
+        // target-native data.
+        private const uint McubootImageMagic = 0x96f3b83d;
+        private const ushort McubootTlvInfoMagic = 0x6907;
+        private const ushort McubootTlvTypeSha256 = 0x10;
+        private const int McubootImageHeaderStructSize = 32;
+
+        private static void WriteUInt16LE(byte[] buffer, int offset, ushort value)
+        {
+            buffer[offset] = (byte)value;
+            buffer[offset + 1] = (byte)(value >> 8);
+        }
+
+        private static void WriteUInt32LE(byte[] buffer, int offset, uint value)
+        {
+            buffer[offset] = (byte)value;
+            buffer[offset + 1] = (byte)(value >> 8);
+            buffer[offset + 2] = (byte)(value >> 16);
+            buffer[offset + 3] = (byte)(value >> 24);
+        }
+
+        /// <summary>
+        /// Builds an MCUboot <c>image_header</c>, padded with the erased-flash value (0xFF) up to
+        /// <paramref name="headerSize"/> bytes, matching what <c>imgtool sign --pad-header</c> produces.
+        /// <c>ih_load_addr</c>, <c>ih_flags</c> and <c>ih_ver</c> are left zeroed: this image is never
+        /// loaded to a fixed address and deployment images aren't independently versioned.
+        /// </summary>
+        private static byte[] BuildMcubootImageHeader(uint headerSize, uint imageSize)
+        {
+            byte[] header = new byte[headerSize];
+
+            for (int i = McubootImageHeaderStructSize; i < header.Length; i++)
+            {
+                header[i] = 0xFF;
+            }
+
+            WriteUInt32LE(header, 0, McubootImageMagic);           // ih_magic
+            WriteUInt16LE(header, 8, (ushort)headerSize);          // ih_hdr_size
+            WriteUInt32LE(header, 12, imageSize);                  // ih_img_size
+
+            return header;
+        }
+
+        /// <summary>
+        /// Builds the unprotected TLV area MCUboot expects right after the image payload: a
+        /// <c>image_tlv_info</c> header followed by a single SHA256 TLV, hashed over the header and
+        /// the image payload exactly like <c>bootutil_img_hash()</c> does on the device.
+        /// </summary>
+        private static byte[] BuildMcubootTlvFooter(byte[] header, List<byte[]> assemblies)
+        {
+            byte[] hash;
+
+            using (SHA256 sha256 = SHA256.Create())
+            {
+                if (assemblies.Count == 0)
+                {
+                    hash = sha256.ComputeHash(header);
+                }
+                else
+                {
+                    sha256.TransformBlock(header, 0, header.Length, null, 0);
+
+                    for (int i = 0; i < assemblies.Count - 1; i++)
+                    {
+                        byte[] assembly = assemblies[i];
+                        sha256.TransformBlock(assembly, 0, assembly.Length, null, 0);
+                    }
+
+                    byte[] lastAssembly = assemblies[assemblies.Count - 1];
+                    sha256.TransformFinalBlock(lastAssembly, 0, lastAssembly.Length);
+
+                    hash = sha256.Hash;
+                }
+            }
+
+            // image_tlv_info (4 bytes) + image_tlv (4 bytes) + SHA256 hash
+            byte[] footer = new byte[4 + 4 + hash.Length];
+
+            WriteUInt16LE(footer, 0, McubootTlvInfoMagic);         // it_magic
+            WriteUInt16LE(footer, 2, (ushort)footer.Length);       // it_tlv_tot
+            WriteUInt16LE(footer, 4, McubootTlvTypeSha256);        // it_type
+            WriteUInt16LE(footer, 6, (ushort)hash.Length);         // it_len
+            Array.Copy(hash, 0, footer, 8, hash.Length);
+
+            return footer;
+        }
+
         private bool DeploymentExecuteIncremental(
             List<byte[]> assemblies,
             bool skipErase = false,
@@ -3103,11 +3223,24 @@ namespace nanoFramework.Tools.Debugger
             // check if we do have the map
             if (FlashSectorMap.Count != 0)
             {
-                // total size of assemblies to deploy 
-                int deployLength = assemblies.Sum(a => a.Length);
+                List<byte[]> chunksToWrite = assemblies;
+
+                if (HasMCUboot)
+                {
+                    // MCUboot targets required a specific layout (header + payload + TLV footer)
+                    byte[] mcubootHeader = BuildMcubootImageHeader(McubootHeaderSize, (uint)assemblies.Sum(a => a.Length));
+                    byte[] mcubootTlvFooter = BuildMcubootTlvFooter(mcubootHeader, assemblies);
+
+                    chunksToWrite = new List<byte[]> { mcubootHeader };
+                    chunksToWrite.AddRange(assemblies);
+                    chunksToWrite.Add(mcubootTlvFooter);
+                }
+
+                // total size of the data to deploy
+                int deployLength = chunksToWrite.Sum(a => a.Length);
 
                 // build the deployment blob from the flash sector map
-                // apply a filter so that we take only the blocks flag for deployment 
+                // apply a filter so that we take only the blocks flag for deployment
                 List<DeploymentSector> deploymentBlob = FlashSectorMap.Where(s => (s.Flags
                                                                                    & Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_MASK) == Commands.Monitor_FlashSectorMap.c_MEMORY_USAGE_DEPLOYMENT)
                                                                       .Select(s => s.ToDeploymentSector())
@@ -3125,21 +3258,21 @@ namespace nanoFramework.Tools.Debugger
                     return false;
                 }
 
-                while (assemblies.Count > 0)
+                while (chunksToWrite.Count > 0)
                 {
                     //
-                    // Only word-aligned assemblies are allowed.
+                    // Only word-aligned chunks are allowed.
                     //
-                    if (assemblies.First().Length % 4 != 0)
+                    if (chunksToWrite.First().Length % 4 != 0)
                     {
-                        log?.Report($"It's only possible to deploy word aligned assemblies. Failed to deploy assembly with {assemblies.First().Length} bytes.");
+                        log?.Report($"It's only possible to deploy word aligned assemblies. Failed to deploy assembly with {chunksToWrite.First().Length} bytes.");
                         progress?.Report(new MessageWithProgress(""));
 
                         return false;
                     }
 
                     // setup counters
-                    int remainingBytes = assemblies.First().Length;
+                    int remainingBytes = chunksToWrite.First().Length;
                     int currentPosition = 0;
 
                     // find first block with available space
@@ -3160,7 +3293,7 @@ namespace nanoFramework.Tools.Debugger
 
                             byte[] tempBuffer = new byte[bytesToCopy];
 
-                            Array.Copy(assemblies.First(), tempBuffer, bytesToCopy);
+                            Array.Copy(chunksToWrite.First(), tempBuffer, bytesToCopy);
                             sector.DeploymentData = tempBuffer;
 
                             remainingBytes -= bytesToCopy;
@@ -3170,8 +3303,8 @@ namespace nanoFramework.Tools.Debugger
 
                     if (remainingBytes == 0)
                     {
-                        // assembly fully stored for deployment, remove it from the list
-                        assemblies.RemoveAt(0);
+                        // chunk fully stored for deployment, remove it from the list
+                        chunksToWrite.RemoveAt(0);
                     }
                     else
                     {


### PR DESCRIPTION
## Description
- Rename monitor flag to match interpreter.
- Adjust output in ToString() for device capabilities.
- Add new flags to monitor Ping to report Mcuboot header size.
- Add helper methods to compute TLV and compose mcuboot valid deployment image.
- Adjust DeploymentExecuteIncremental() to generate and use mcuboot valid deployment image.

## Motivation and Context
- Related with nanoframework/Home#1709

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Deploying app in mcuboot enabled device.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
