### PR TITLE
Implement commands to manage IFU images

### DIFF
--- a/USB Test App WPF/MainWindow.xaml
+++ b/USB Test App WPF/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:ViewModel="clr-namespace:Serial_Test_App_WPF.ViewModel"
         x:Class="Serial_Test_App_WPF.MainWindow"
         mc:Ignorable="d"
-        Title="MainWindow" Height="374" Width="570.729">
+        Title="MainWindow" Height="410" Width="570.729">
     <Window.Resources>
         <DataTemplate x:Key="NanoDevicesItemTemplate">
             <TextBlock Text="{Binding Path=Description}"/>
@@ -55,5 +55,9 @@
         <Button Content="Reboot CLR" HorizontalAlignment="Left" Margin="364,77,0,0" VerticalAlignment="Top" Width="121" Click="RebootDeviceButton_Click"/>
         <Button Content="Upload File I:\" HorizontalAlignment="Left" Margin="39,306,0,0" VerticalAlignment="Top" Width="110" Click="UploadFileInternalStorage_Click"/>
         <Button Content="Rm file I:\" HorizontalAlignment="Left" Margin="162,306,0,0" VerticalAlignment="Top" Width="75" Click="RemoveFileInternalStorage_Click"/>
+
+        <Button Content="List Images" HorizontalAlignment="Left" Margin="39,337,0,0" VerticalAlignment="Top" Width="110" Click="ListImagesButton_Click" />
+        <Button Content="Erase CLR Update" HorizontalAlignment="Left" Margin="162,337,0,0" VerticalAlignment="Top" Width="110" Click="EraseClrUpdateButton_Click" />
+        <Button Content="Erase Deployment Update" HorizontalAlignment="Left" Margin="284,337,0,0" VerticalAlignment="Top" Width="150" Click="EraseDeploymentUpdateButton_Click" />
     </Grid>
 </Window>

--- a/USB Test App WPF/MainWindow.xaml.cs
+++ b/USB Test App WPF/MainWindow.xaml.cs
@@ -730,13 +730,24 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 
             try
             {
-                var images = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.GetImageInfo();
+                var debugEngine = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine;
 
-                Debug.WriteLine("");
-                Debug.WriteLine("");
-                Debug.WriteLine(images.ToStringForOutput());
-                Debug.WriteLine("");
-                Debug.WriteLine("");
+                if (!debugEngine.HasMCUboot)
+                {
+                    Debug.WriteLine("");
+                    Debug.WriteLine("Target device doesn't support MCUboot images.");
+                    Debug.WriteLine("");
+                }
+                else
+                {
+                    var images = debugEngine.GetImageInfo();
+
+                    Debug.WriteLine("");
+                    Debug.WriteLine("");
+                    Debug.WriteLine(images.ToStringForOutput());
+                    Debug.WriteLine("");
+                    Debug.WriteLine("");
+                }
             }
             catch
             {
@@ -754,13 +765,24 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 
             try
             {
-                var result = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.EraseImage((uint)MonitorImageIndex.Clr, (uint)MonitorImageSlot.Secondary);
+                var debugEngine = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine;
 
-                Debug.WriteLine("");
-                Debug.WriteLine("");
-                Debug.WriteLine($"Erase CLR update (image 0, secondary slot): {(result.Success ? "SUCCESS" : "FAILED")} - {result.ErrorCode}");
-                Debug.WriteLine("");
-                Debug.WriteLine("");
+                if (!debugEngine.HasMCUboot)
+                {
+                    Debug.WriteLine("");
+                    Debug.WriteLine("Target device doesn't support MCUboot images.");
+                    Debug.WriteLine("");
+                }
+                else
+                {
+                    var result = debugEngine.EraseImage((uint)MonitorImageIndex.Clr, (uint)MonitorImageSlot.Secondary);
+
+                    Debug.WriteLine("");
+                    Debug.WriteLine("");
+                    Debug.WriteLine($"Erase CLR update (image 0, secondary slot): {(result.Success ? "SUCCESS" : "FAILED")} - {result.ErrorCode}");
+                    Debug.WriteLine("");
+                    Debug.WriteLine("");
+                }
             }
             catch
             {
@@ -778,13 +800,24 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 
             try
             {
-                var result = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.EraseImage((uint)MonitorImageIndex.Deployment, (uint)MonitorImageSlot.Secondary);
+                var debugEngine = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine;
 
-                Debug.WriteLine("");
-                Debug.WriteLine("");
-                Debug.WriteLine($"Erase Deployment update (image 1, secondary slot): {(result.Success ? "SUCCESS" : "FAILED")} - {result.ErrorCode}");
-                Debug.WriteLine("");
-                Debug.WriteLine("");
+                if (!debugEngine.HasMCUboot)
+                {
+                    Debug.WriteLine("");
+                    Debug.WriteLine("Target device doesn't support MCUboot images.");
+                    Debug.WriteLine("");
+                }
+                else
+                {
+                    var result = debugEngine.EraseImage((uint)MonitorImageIndex.Deployment, (uint)MonitorImageSlot.Secondary);
+
+                    Debug.WriteLine("");
+                    Debug.WriteLine("");
+                    Debug.WriteLine($"Erase Deployment update (image 1, secondary slot): {(result.Success ? "SUCCESS" : "FAILED")} - {result.ErrorCode}");
+                    Debug.WriteLine("");
+                    Debug.WriteLine("");
+                }
             }
             catch
             {

--- a/USB Test App WPF/MainWindow.xaml.cs
+++ b/USB Test App WPF/MainWindow.xaml.cs
@@ -723,6 +723,78 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
             (sender as Button).IsEnabled = true;
         }
 
+        private void ListImagesButton_Click(object sender, RoutedEventArgs e)
+        {
+            // disable button
+            (sender as Button).IsEnabled = false;
+
+            try
+            {
+                var images = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.GetImageInfo();
+
+                Debug.WriteLine("");
+                Debug.WriteLine("");
+                Debug.WriteLine(images.ToStringForOutput());
+                Debug.WriteLine("");
+                Debug.WriteLine("");
+            }
+            catch
+            {
+
+            }
+
+            // enable button
+            (sender as Button).IsEnabled = true;
+        }
+
+        private void EraseClrUpdateButton_Click(object sender, RoutedEventArgs e)
+        {
+            // disable button
+            (sender as Button).IsEnabled = false;
+
+            try
+            {
+                var result = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.EraseImage((uint)MonitorImageIndex.Clr, (uint)MonitorImageSlot.Secondary);
+
+                Debug.WriteLine("");
+                Debug.WriteLine("");
+                Debug.WriteLine($"Erase CLR update (image 0, secondary slot): {(result.Success ? "SUCCESS" : "FAILED")} - {result.ErrorCode}");
+                Debug.WriteLine("");
+                Debug.WriteLine("");
+            }
+            catch
+            {
+
+            }
+
+            // enable button
+            (sender as Button).IsEnabled = true;
+        }
+
+        private void EraseDeploymentUpdateButton_Click(object sender, RoutedEventArgs e)
+        {
+            // disable button
+            (sender as Button).IsEnabled = false;
+
+            try
+            {
+                var result = (DataContext as MainViewModel).AvailableDevices[DeviceGrid.SelectedIndex].DebugEngine.EraseImage((uint)MonitorImageIndex.Deployment, (uint)MonitorImageSlot.Secondary);
+
+                Debug.WriteLine("");
+                Debug.WriteLine("");
+                Debug.WriteLine($"Erase Deployment update (image 1, secondary slot): {(result.Success ? "SUCCESS" : "FAILED")} - {result.ErrorCode}");
+                Debug.WriteLine("");
+                Debug.WriteLine("");
+            }
+            catch
+            {
+
+            }
+
+            // enable button
+            (sender as Button).IsEnabled = true;
+        }
+
         private void IsInitStateButton_Click(object sender, RoutedEventArgs e)
         {
             // disable button

--- a/nanoFramework.Tools.DebugLibrary.Shared/Extensions/OutputExtensions.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/Extensions/OutputExtensions.cs
@@ -178,6 +178,87 @@ namespace nanoFramework.Tools.Debugger.Extensions
             return "Invalid or empty map data.";
         }
 
+        public static string ToStringForOutput(this List<Commands.Monitor_ImageInfo.Entry> images)
+        {
+            StringBuilder output = new StringBuilder();
+
+            try
+            {
+                if (images != null && images.Count > 0)
+                {
+                    output.AppendLine("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+                    output.AppendLine("++                    MCUboot Image Info                     ++");
+                    output.AppendLine("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+
+                    foreach (Commands.Monitor_ImageInfo.Entry entry in images)
+                    {
+                        string imageName = entry.ImageIndex == (byte)MonitorImageIndex.Clr ? "CLR" : "Deployment";
+
+                        if (entry.SlotIndex == (byte)MonitorImageSlot.Secondary)
+                        {
+                            output.AppendLine();
+                            output.AppendLine("  Update slot:");
+                            output.Append(ImageInfoEntryToStringForOutput(entry, "    "));
+                            output.AppendLine();
+                        }
+                        else
+                        {
+                            output.AppendLine($"{imageName}:");
+                            output.Append(ImageInfoEntryToStringForOutput(entry, "  "));
+                        }
+                    }
+
+                    return output.ToString();
+                }
+
+                return "No image info available.";
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Exception when parsing image info data: {ex.Message + Environment.NewLine + ex.StackTrace}");
+            }
+
+            return "Exception when trying to parse image info data.";
+        }
+
+        private static string ImageInfoEntryToStringForOutput(Commands.Monitor_ImageInfo.Entry entry, string indent)
+        {
+            StringBuilder output = new StringBuilder();
+            MonitorImageStateFlags flags = (MonitorImageStateFlags)entry.Flags;
+
+            output.AppendLine($"{indent}Valid Header : {(entry.ValidHeader != 0 ? "YES" : "NO")}");
+
+            if (entry.ValidHeader != 0)
+            {
+                // MCUboot version string format is "major.minor.revision[+build]" (build number
+                // is only appended when non-zero) - see imgtool/version.py's SemiSemVersion.
+                string version = $"{entry.Version.MajorVersion}.{entry.Version.MinorVersion}.{entry.Version.RevisionNumber}";
+
+                if (entry.Version.BuildNumber != 0)
+                {
+                    version += $"+{entry.Version.BuildNumber}";
+                }
+
+                output.AppendLine($"{indent}Version      : {version}");
+                output.AppendLine($"{indent}Hash         : {BitConverter.ToString(entry.Hash).Replace("-", "")}");
+                output.AppendLine($"{indent}Bootable     : {(flags.HasFlag(MonitorImageStateFlags.Bootable) ? "YES" : "NO")}");
+            }
+
+            output.AppendLine($"{indent}Active       : {(flags.HasFlag(MonitorImageStateFlags.Active) ? "YES" : "NO")}");
+            output.AppendLine($"{indent}Confirmed    : {(flags.HasFlag(MonitorImageStateFlags.Confirmed) ? "YES" : "NO")}");
+
+            string pending = "NO";
+
+            if (flags.HasFlag(MonitorImageStateFlags.Pending))
+            {
+                pending = flags.HasFlag(MonitorImageStateFlags.Permanent) ? "YES (Permanent)" : "YES (Test)";
+            }
+
+            output.AppendLine($"{indent}Pending      : {pending}");
+
+            return output.ToString();
+        }
+
         public static string ToStringForOutput(this DeviceConfiguration.NetworkConfigurationProperties networkConfiguration)
         {
             StringBuilder output = new StringBuilder();

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Commands.cs
@@ -81,6 +81,139 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         NotSupported = 0xFFFF,
     }
 
+    /// <summary>
+    /// Image indexes used by the IFU (In-Field Update) image commands.
+    /// </summary>
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // NEED TO KEEP THESE IN SYNC WITH the image index convention in native Debugger.cpp/WireProtocol_MonitorCommands.h //
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    public enum MonitorImageIndex : byte
+    {
+        /// <summary>
+        /// The nanoCLR firmware image.
+        /// </summary>
+        Clr = 0,
+
+        /// <summary>
+        /// The deployment (managed application) image.
+        /// </summary>
+        Deployment = 1,
+    }
+
+    /// <summary>
+    /// Slot indexes used by the IFU (In-Field Update) image commands.
+    /// </summary>
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    // NEED TO KEEP THESE IN SYNC WITH native 'Monitor_Image_Slot' enum in WireProtocol_MonitorCommands.h //
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    public enum MonitorImageSlot : byte
+    {
+        /// <summary>
+        /// Primary (running) slot - unverified developer write path.
+        /// </summary>
+        Primary = 0,
+
+        /// <summary>
+        /// Secondary (staging) slot - normal update path, triggers a one-time test-swap.
+        /// </summary>
+        Secondary = 1,
+    }
+
+    /// <summary>
+    /// State flags reported per slot by <see cref="Commands.Monitor_ImageInfo"/>.
+    /// </summary>
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
+    // NEED TO KEEP THESE IN SYNC WITH native 'Monitor_Image_StateFlags' enum in WireProtocol_MonitorCommands.h //
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
+    [Flags]
+    public enum MonitorImageStateFlags : byte
+    {
+        /// <summary>
+        /// No flags set.
+        /// </summary>
+        None = 0x00,
+
+        /// <summary>
+        /// Image is the one currently running.
+        /// </summary>
+        Active = 0x01,
+
+        /// <summary>
+        /// Image is confirmed (permanent - no revert).
+        /// </summary>
+        Confirmed = 0x02,
+
+        /// <summary>
+        /// Image is scheduled for a one-time test-swap.
+        /// </summary>
+        Pending = 0x04,
+
+        /// <summary>
+        /// The pending swap is permanent (no revert). Only meaningful together with <see cref="Pending"/>;
+        /// when unset, a pending swap is a revertible test-swap.
+        /// </summary>
+        Permanent = 0x08,
+
+        /// <summary>
+        /// Image is bootable (IMAGE_F_NON_BOOTABLE is not set in the image header flags).
+        /// </summary>
+        Bootable = 0x10,
+    }
+
+    /// <summary>
+    /// Error codes carried in the ErrorCode field of the IFU (In-Field Update) command replies.
+    /// </summary>
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    // NEED TO KEEP THESE IN SYNC WITH native 'Monitor_Image_Error' enum in WireProtocol_MonitorCommands.h //
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    public enum MonitorImageErrorCode : uint
+    {
+        /// <summary>
+        /// Operation succeeded.
+        /// </summary>
+        Success = 0,
+
+        /// <summary>
+        /// Invalid image or slot index.
+        /// </summary>
+        BadArgument = 1,
+
+        /// <summary>
+        /// Could not open the target flash area.
+        /// </summary>
+        FlashOpen = 2,
+
+        /// <summary>
+        /// First chunk is not a valid MCUboot image.
+        /// </summary>
+        BadMagic = 3,
+
+        /// <summary>
+        /// Image would exceed the target slot capacity.
+        /// </summary>
+        TooLarge = 4,
+
+        /// <summary>
+        /// Flash erase failed.
+        /// </summary>
+        Erase = 5,
+
+        /// <summary>
+        /// Flash write failed.
+        /// </summary>
+        Write = 6,
+
+        /// <summary>
+        /// boot_set_pending failed.
+        /// </summary>
+        SetPending = 7,
+
+        /// <summary>
+        /// boot_set_confirmed failed.
+        /// </summary>
+        Confirm = 8,
+    }
+
     public class Commands
     {
         public const uint c_Monitor_Ping = 0x00000000; // The payload is empty, this command is used to let the other side know we are here...
@@ -100,6 +233,12 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
         public const uint c_Monitor_UpdateConfiguration = 0x00000010;
         public const uint c_Monitor_StorageOperation = 0x00000011;
         public const uint c_Monitor_TargetInfo = 0x00000020;
+
+        // IFU (In-Field Update) commands
+        public const uint c_Monitor_ImageInfo = 0x00000021;
+        public const uint c_Monitor_ImageWrite = 0x00000022;
+        public const uint c_Monitor_ImageConfirm = 0x00000023;
+        public const uint c_Monitor_ImageErase = 0x00000024;
 
         public class Monitor_Message : IConverter
         {
@@ -712,6 +851,187 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                 /// If the file doesn't exist, no action is taken.
                 /// </remarks>
                 Append = 3
+            }
+        }
+
+        //////////////////////////////////////////////////////////////////////////////////////
+        // IFU (In-Field Update) commands - MCUboot targets only                            //
+        //////////////////////////////////////////////////////////////////////////////////////
+
+        /// <summary>
+        /// Queries the MCUboot image/slot state. The request payload is empty.
+        /// </summary>
+        public class Monitor_ImageInfo
+        {
+            /// <summary>
+            /// MCUboot image header version. Mirrors struct image_version in bootutil/image.h.
+            /// </summary>
+            public class ImageVersion
+            {
+                public byte MajorVersion;
+                public byte MinorVersion;
+                public ushort RevisionNumber;
+                public uint BuildNumber;
+            }
+
+            /// <summary>
+            /// Per (image, slot) state, as reported by the target device.
+            /// </summary>
+            public class Entry
+            {
+                /// <summary>
+                /// 0 = nanoCLR, 1 = deployment.
+                /// </summary>
+                public byte ImageIndex;
+
+                /// <summary>
+                /// 0 = primary, 1 = secondary. See <see cref="MonitorImageSlot"/>.
+                /// </summary>
+                public byte SlotIndex;
+
+                /// <summary>
+                /// <see cref="MonitorImageStateFlags"/> bitmask.
+                /// </summary>
+                public byte Flags;
+
+                /// <summary>
+                /// Non-zero when both the image header magic and the TLV info magic parse correctly.
+                /// This is a structural sanity check only - no hash or signature is verified.
+                /// </summary>
+                public byte ValidHeader;
+
+                public ImageVersion Version = new ImageVersion();
+
+                /// <summary>
+                /// SHA-256 of the image (from IMAGE_TLV_SHA256).
+                /// </summary>
+                public byte[] Hash = new byte[32];
+            }
+
+            public class Reply : IConverter
+            {
+                // size, in bytes, of a single Entry on the wire: 4 (ImageIndex+SlotIndex+Flags+ValidHeader)
+                // + 8 (Version) + 32 (Hash)
+                private const int c_EntrySize = 44;
+
+                public byte ImageCount;
+                public List<Entry> Images;
+
+                public void PrepareForDeserialize(int size, byte[] data, Converter converter)
+                {
+                    int num = (size - 1) / c_EntrySize;
+
+                    Images = Enumerable.Range(0, num).Select(x => new Entry()).ToList();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Writes a chunk of MCUboot image data to a target slot.
+        /// </summary>
+        public class Monitor_ImageWrite : OverheadBase
+        {
+            /// <summary>
+            /// 0 = CLR firmware, 1 = deployment.
+            /// </summary>
+            public byte ImageIndex;
+
+            /// <summary>
+            /// 0 = primary (dev path), 1 = secondary (normal update path). See <see cref="MonitorImageSlot"/>.
+            /// </summary>
+            public byte SlotIndex;
+
+            /// <summary>
+            /// Byte offset within the target slot.
+            /// </summary>
+            public uint Offset;
+
+            /// <summary>
+            /// Total image size. Only meaningful when <see cref="Offset"/> == 0.
+            /// </summary>
+            public uint TotalSize;
+
+            public byte[] Data;
+
+            public class Reply
+            {
+                /// <summary>
+                /// 0 = success. See <see cref="MonitorImageErrorCode"/>.
+                /// </summary>
+                public uint ErrorCode;
+
+                /// <summary>
+                /// Next expected offset for flow control.
+                /// </summary>
+                public uint NextOffset;
+            }
+
+            public void PrepareForSend(
+                byte imageIndex,
+                byte slotIndex,
+                uint totalSize,
+                byte[] data,
+                int offset,
+                int length)
+            {
+                ImageIndex = imageIndex;
+                SlotIndex = slotIndex;
+                TotalSize = totalSize;
+
+                PrepareForSend(data, offset, length);
+            }
+
+            public override bool PrepareForSend(byte[] data, int offset, int length)
+            {
+                Offset = (uint)offset;
+                Data = new byte[length];
+
+                Array.Copy(data, offset, Data, 0, length);
+
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Confirms the currently running image as permanent.
+        /// </summary>
+        public class Monitor_ImageConfirm
+        {
+            /// <summary>
+            /// Image to confirm (defaults to 0, the nanoCLR image).
+            /// </summary>
+            public uint ImageIndex;
+
+            public class Reply
+            {
+                /// <summary>
+                /// 0 = success. See <see cref="MonitorImageErrorCode"/>.
+                /// </summary>
+                public uint ErrorCode;
+            }
+        }
+
+        /// <summary>
+        /// Erases a slot (typically the secondary slot).
+        /// </summary>
+        public class Monitor_ImageErase
+        {
+            /// <summary>
+            /// Image whose slot is to be erased.
+            /// </summary>
+            public uint ImageIndex;
+
+            /// <summary>
+            /// Slot to erase. See <see cref="MonitorImageSlot"/>.
+            /// </summary>
+            public uint SlotIndex;
+
+            public class Reply
+            {
+                /// <summary>
+                /// 0 = success. See <see cref="MonitorImageErrorCode"/>.
+                /// </summary>
+                public uint ErrorCode;
             }
         }
 
@@ -2076,6 +2396,11 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                     case c_Monitor_UpdateConfiguration: return new Monitor_UpdateConfiguration.Reply();
                     case c_Monitor_StorageOperation: return new Monitor_StorageOperation.Reply();
 
+                    case c_Monitor_ImageInfo: return new Monitor_ImageInfo.Reply();
+                    case c_Monitor_ImageWrite: return new Monitor_ImageWrite.Reply();
+                    case c_Monitor_ImageConfirm: return new Monitor_ImageConfirm.Reply();
+                    case c_Monitor_ImageErase: return new Monitor_ImageErase.Reply();
+
                     case c_Debugging_Execution_BasePtr: return new Debugging_Execution_BasePtr.Reply();
                     case c_Debugging_Execution_ChangeConditions: return new DebuggingExecutionChangeConditions.Reply();
                     case c_Debugging_Execution_Allocate: return new Debugging_Execution_Allocate.Reply();
@@ -2149,6 +2474,11 @@ namespace nanoFramework.Tools.Debugger.WireProtocol
                     case c_Monitor_FlashSectorMap: return new Monitor_FlashSectorMap();
                     case c_Monitor_QueryConfiguration: return new Monitor_QueryConfiguration();
                     case c_Monitor_StorageOperation: return new Monitor_StorageOperation();
+
+                    case c_Monitor_ImageInfo: return new Monitor_ImageInfo();
+                    case c_Monitor_ImageWrite: return new Monitor_ImageWrite();
+                    case c_Monitor_ImageConfirm: return new Monitor_ImageConfirm();
+                    case c_Monitor_ImageErase: return new Monitor_ImageErase();
 
                     case c_Debugging_Execution_BasePtr: return new Debugging_Execution_BasePtr();
                     case c_Debugging_Execution_ChangeConditions: return new DebuggingExecutionChangeConditions();

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -1816,6 +1816,130 @@ namespace nanoFramework.Tools.Debugger
             return (AccessMemoryErrorCodes.Unknown, false);
         }
 
+        #region IFU (In-Field Update) commands
+
+        /// <summary>
+        /// Queries the MCUboot image/slot state for all images on the target device.
+        /// Only meaningful when <see cref="HasMCUboot"/> is <see langword="true"/>.
+        /// </summary>
+        public List<Commands.Monitor_ImageInfo.Entry> GetImageInfo()
+        {
+            IncomingMessage reply = PerformSyncRequest(Commands.c_Monitor_ImageInfo, 0, null);
+
+            if (reply != null)
+            {
+                if (reply.Payload is Commands.Monitor_ImageInfo.Reply cmdReply)
+                {
+                    return cmdReply.Images;
+                }
+            }
+
+            return new List<Commands.Monitor_ImageInfo.Entry>();
+        }
+
+        /// <summary>
+        /// Writes an MCUboot image to the given slot on the target device, in chunks.
+        /// Writing to the secondary slot schedules a one-time test-swap on the next reboot;
+        /// writing to the primary slot does not (developer path).
+        /// Only meaningful when <see cref="HasMCUboot"/> is <see langword="true"/>.
+        /// </summary>
+        public MonitorImageErrorCode WriteImage(
+            byte imageIndex,
+            byte slotIndex,
+            byte[] imageData,
+            IProgress<MessageWithProgress> progress = null,
+            IProgress<string> log = null)
+        {
+            int count = imageData.Length;
+            int position = 0;
+
+            MonitorImageErrorCode result = MonitorImageErrorCode.Success;
+
+            while (count > 0)
+            {
+                Commands.Monitor_ImageWrite cmd = new Commands.Monitor_ImageWrite();
+
+                int packetLength = Math.Min(GetPacketMaxLength(cmd), count);
+
+                cmd.PrepareForSend(imageIndex, slotIndex, (uint)imageData.Length, imageData, position, packetLength);
+
+                progress?.Report(new MessageWithProgress($"Writing image {position + packetLength}/{imageData.Length} bytes...", (uint)(position + packetLength), (uint)imageData.Length));
+                log?.Report($"Writing {position + packetLength}/{imageData.Length} bytes to image {imageIndex}, slot {slotIndex}.");
+
+                IncomingMessage reply = PerformSyncRequest(Commands.c_Monitor_ImageWrite, 0, cmd, 4 * DefaultTimeout);
+
+                if (reply == null || !(reply.Payload is Commands.Monitor_ImageWrite.Reply cmdReply))
+                {
+                    progress?.Report(new MessageWithProgress(""));
+                    log?.Report($"Error writing image data @ offset {position}. No reply from nanoDevice.");
+
+                    return MonitorImageErrorCode.Write;
+                }
+
+                result = (MonitorImageErrorCode)cmdReply.ErrorCode;
+
+                if (result != MonitorImageErrorCode.Success)
+                {
+                    progress?.Report(new MessageWithProgress(""));
+                    log?.Report($"Error writing image data @ offset {position}: {result}.");
+
+                    return result;
+                }
+
+                count -= packetLength;
+                position = (int)cmdReply.NextOffset;
+            }
+
+            progress?.Report(new MessageWithProgress(""));
+
+            return result;
+        }
+
+        /// <summary>
+        /// Confirms the currently running image as permanent, preventing MCUboot from reverting it on the next boot.
+        /// Only meaningful when <see cref="HasMCUboot"/> is <see langword="true"/>.
+        /// </summary>
+        public (MonitorImageErrorCode ErrorCode, bool Success) ConfirmImage(uint imageIndex = 0)
+        {
+            Commands.Monitor_ImageConfirm cmd = new Commands.Monitor_ImageConfirm
+            {
+                ImageIndex = imageIndex
+            };
+
+            IncomingMessage reply = PerformSyncRequest(Commands.c_Monitor_ImageConfirm, 0, cmd);
+
+            if (reply != null && reply.Payload is Commands.Monitor_ImageConfirm.Reply cmdReply)
+            {
+                return ((MonitorImageErrorCode)cmdReply.ErrorCode, reply.IsPositiveAcknowledge());
+            }
+
+            return (MonitorImageErrorCode.Confirm, false);
+        }
+
+        /// <summary>
+        /// Erases a slot (typically the secondary slot) for the given image.
+        /// Only meaningful when <see cref="HasMCUboot"/> is <see langword="true"/>.
+        /// </summary>
+        public (MonitorImageErrorCode ErrorCode, bool Success) EraseImage(uint imageIndex, uint slotIndex)
+        {
+            Commands.Monitor_ImageErase cmd = new Commands.Monitor_ImageErase
+            {
+                ImageIndex = imageIndex,
+                SlotIndex = slotIndex
+            };
+
+            IncomingMessage reply = PerformSyncRequest(Commands.c_Monitor_ImageErase, 0, cmd, 4 * DefaultTimeout);
+
+            if (reply != null && reply.Payload is Commands.Monitor_ImageErase.Reply cmdReply)
+            {
+                return ((MonitorImageErrorCode)cmdReply.ErrorCode, reply.IsPositiveAcknowledge());
+            }
+
+            return (MonitorImageErrorCode.Erase, false);
+        }
+
+        #endregion
+
         public bool ExecuteMemory(uint address)
         {
             Commands.Monitor_Execute cmd = new Commands.Monitor_Execute
@@ -3125,14 +3249,14 @@ namespace nanoFramework.Tools.Debugger
         }
 
         // MCUboot image_header / TLV constants used to compose a deployment image below.
-        // See struct image_header / image_tlv_info / image_tlv in
-        // boot/bootutil/include/bootutil/image.h (mcu-tools/mcuboot). All fields are little endian,
-        // regardless of target byte order - this is the on-the-wire MCUboot image format, not
-        // target-native data.
         private const uint McubootImageMagic = 0x96f3b83d;
         private const ushort McubootTlvInfoMagic = 0x6907;
         private const ushort McubootTlvTypeSha256 = 0x10;
         private const int McubootImageHeaderStructSize = 32;
+
+        // MCUboot writes its own trailer at the tail of every primary slot.
+        // This is a flat 1 kB reserve, that keeps deployment writes from ever landing on it.
+        private const int McubootTrailerReserve = 1024;
 
         private static void WriteUInt16LE(byte[] buffer, int offset, ushort value)
         {
@@ -3247,10 +3371,15 @@ namespace nanoFramework.Tools.Debugger
                                                                       .ToList();
 
                 // rough check if there is enough room to deploy
-                if (deploymentBlob.ToDeploymentBlockList().Sum(b => b.Size) < deployLength)
+                //
+                // On MCUboot targets, hold back McubootTrailerReserve bytes at the tail of the reported region.
+                int reportedCapacity = deploymentBlob.ToDeploymentBlockList().Sum(b => b.Size);
+                int usableCapacity = HasMCUboot ? (reportedCapacity - McubootTrailerReserve) : reportedCapacity;
+
+                if (usableCapacity < deployLength)
                 {
                     // compose error message
-                    string errorMessage = $"Deployment storage (available size: {deploymentBlob.ToDeploymentBlockList().Sum(b => b.Size)} bytes) is not large enough for assemblies to deploy (total size: {deployLength} bytes).";
+                    string errorMessage = $"Deployment storage (available size: {usableCapacity} bytes) is not large enough for assemblies to deploy (total size: {deployLength} bytes).";
 
                     log?.Report(errorMessage);
                     progress?.Report(new MessageWithProgress(""));

--- a/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
+++ b/nanoFramework.Tools.DebugLibrary.Shared/WireProtocol/Engine.cs
@@ -1876,6 +1876,14 @@ namespace nanoFramework.Tools.Debugger
                     return MonitorImageErrorCode.Write;
                 }
 
+                if (!reply.IsPositiveAcknowledge())
+                {
+                    progress?.Report(new MessageWithProgress(""));
+                    log?.Report($"Error writing image data @ offset {position}. Negative acknowledgment from nanoDevice.");
+
+                    return MonitorImageErrorCode.Write;
+                }
+
                 result = (MonitorImageErrorCode)cmdReply.ErrorCode;
 
                 if (result != MonitorImageErrorCode.Success)
@@ -1886,8 +1894,18 @@ namespace nanoFramework.Tools.Debugger
                     return result;
                 }
 
-                count -= packetLength;
-                position = (int)cmdReply.NextOffset;
+                int nextPosition = (int)cmdReply.NextOffset;
+
+                if (nextPosition <= position || nextPosition > imageData.Length)
+                {
+                    progress?.Report(new MessageWithProgress(""));
+                    log?.Report($"Error writing image data @ offset {position}. Invalid next offset {nextPosition} reported by nanoDevice.");
+
+                    return MonitorImageErrorCode.Write;
+                }
+
+                position = nextPosition;
+                count = imageData.Length - position;
             }
 
             progress?.Report(new MessageWithProgress(""));
@@ -1910,7 +1928,9 @@ namespace nanoFramework.Tools.Debugger
 
             if (reply != null && reply.Payload is Commands.Monitor_ImageConfirm.Reply cmdReply)
             {
-                return ((MonitorImageErrorCode)cmdReply.ErrorCode, reply.IsPositiveAcknowledge());
+                MonitorImageErrorCode errorCode = (MonitorImageErrorCode)cmdReply.ErrorCode;
+
+                return (errorCode, reply.IsPositiveAcknowledge() && errorCode == MonitorImageErrorCode.Success);
             }
 
             return (MonitorImageErrorCode.Confirm, false);
@@ -1932,7 +1952,9 @@ namespace nanoFramework.Tools.Debugger
 
             if (reply != null && reply.Payload is Commands.Monitor_ImageErase.Reply cmdReply)
             {
-                return ((MonitorImageErrorCode)cmdReply.ErrorCode, reply.IsPositiveAcknowledge());
+                MonitorImageErrorCode errorCode = (MonitorImageErrorCode)cmdReply.ErrorCode;
+
+                return (errorCode, reply.IsPositiveAcknowledge() && errorCode == MonitorImageErrorCode.Success);
             }
 
             return (MonitorImageErrorCode.Erase, false);


### PR DESCRIPTION
## Description
- Add list, upload, confirm and erase.
- Add operations to test app.

## Motivation and Context
- Related with nanoframework/Home#1709

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Test app in repo.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
